### PR TITLE
[Clothes] 의상 삭제 기능 구현

### DIFF
--- a/src/main/java/org/ikuzo/otboo/domain/clothes/controller/ClothesController.java
+++ b/src/main/java/org/ikuzo/otboo/domain/clothes/controller/ClothesController.java
@@ -78,7 +78,7 @@ public class ClothesController implements ClothesApi {
 
         clothesService.delete(clothesId);
 
-        log.info("[Controller] 의상 삭제 완료 (커밋 후 이미지 정리 예정) - clothesId: {}", clothesId);
+        log.info("[Controller] 의상 삭제 완료 - clothesId: {}", clothesId);
 
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }

--- a/src/main/java/org/ikuzo/otboo/domain/clothes/controller/ClothesController.java
+++ b/src/main/java/org/ikuzo/otboo/domain/clothes/controller/ClothesController.java
@@ -72,7 +72,7 @@ public class ClothesController implements ClothesApi {
     @DeleteMapping("/{clothesId}")
     @Override
     public ResponseEntity<Void> delete(
-        @PathVariable UUID clothesId
+        @PathVariable("clothesId") UUID clothesId
     ) {
         log.info("[Controller] 의상 삭제 요청 - clothesId: {}", clothesId);
 

--- a/src/main/java/org/ikuzo/otboo/domain/clothes/controller/ClothesController.java
+++ b/src/main/java/org/ikuzo/otboo/domain/clothes/controller/ClothesController.java
@@ -12,6 +12,7 @@ import org.ikuzo.otboo.domain.clothes.service.ClothesService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -66,5 +67,19 @@ public class ClothesController implements ClothesApi {
         log.info("[Controller] 의상 수정 완료 - name: {}", response.name());
 
         return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @DeleteMapping("/{clothesId}")
+    @Override
+    public ResponseEntity<Void> delete(
+        @PathVariable UUID clothesId
+    ) {
+        log.info("[Controller] 의상 삭제 요청 - clothesId: {}", clothesId);
+
+        clothesService.delete(clothesId);
+
+        log.info("[Controller] 의상 삭제 완료 (커밋 후 이미지 정리 예정) - clothesId: {}", clothesId);
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/src/main/java/org/ikuzo/otboo/domain/clothes/controller/api/ClothesApi.java
+++ b/src/main/java/org/ikuzo/otboo/domain/clothes/controller/api/ClothesApi.java
@@ -71,13 +71,10 @@ public interface ClothesApi {
         @ApiResponse(
             responseCode = "204",
             description = "의상 삭제 성공",
-            content = @Content(
-                mediaType = "*/*",
-                schema = @Schema(implementation = ClothesDto.class)
-            )
+            content = @Content()
         ),
         @ApiResponse(
-            responseCode = "400",
+            responseCode = "404",
             description = "의상 삭제 실패",
             content = @Content(
                 mediaType = "*/*",

--- a/src/main/java/org/ikuzo/otboo/domain/clothes/controller/api/ClothesApi.java
+++ b/src/main/java/org/ikuzo/otboo/domain/clothes/controller/api/ClothesApi.java
@@ -66,4 +66,25 @@ public interface ClothesApi {
         MultipartFile image
     );
 
+    @Operation(summary = "의상 삭제")
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "204",
+            description = "의상 삭제 성공",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ClothesDto.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "의상 삭제 실패",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class)
+            )
+        )
+    })
+    ResponseEntity<Void> delete(UUID clothesId);
+
 }

--- a/src/main/java/org/ikuzo/otboo/domain/clothes/service/ClothesService.java
+++ b/src/main/java/org/ikuzo/otboo/domain/clothes/service/ClothesService.java
@@ -12,4 +12,6 @@ public interface ClothesService {
 
     ClothesDto update(UUID clothesId, ClothesUpdateRequest request, MultipartFile image);
 
+    void delete(UUID clothesId);
+
 }

--- a/src/main/java/org/ikuzo/otboo/domain/clothes/service/impl/ClothesServiceImpl.java
+++ b/src/main/java/org/ikuzo/otboo/domain/clothes/service/impl/ClothesServiceImpl.java
@@ -103,6 +103,25 @@ public class ClothesServiceImpl implements ClothesService {
         return clothesMapper.toDto(savedClothes);
     }
 
+    @Transactional
+    @Override
+    public void delete(UUID clothesId) {
+
+        log.info("[Service] 의상 삭제 시작 - clothesId: {}", clothesId);
+
+        Clothes clothes = clothesRepository.findById(clothesId)
+                .orElseThrow(() -> new ClothesNotFoundException(clothesId));
+
+        String oldImageUrl = clothes.getImageUrl();
+
+        clothesRepository.delete(clothes);
+
+        imageSwapHelper.deleteAfterCommit(oldImageUrl, "의상 삭제");
+
+        log.info("[Service] 의상 삭제 완료 - clothesId: {}", clothesId);
+
+    }
+
     private void validateClothesCreateRequest (ClothesCreateRequest request) {
         if (request.ownerId() == null) {
             throw new MissingRequiredFieldException("ownerId is null");

--- a/src/main/java/org/ikuzo/otboo/domain/clothes/service/impl/ClothesServiceImpl.java
+++ b/src/main/java/org/ikuzo/otboo/domain/clothes/service/impl/ClothesServiceImpl.java
@@ -50,7 +50,7 @@ public class ClothesServiceImpl implements ClothesService {
 
         String imageUrl = null;
         if (image != null && !image.isEmpty()) {
-            imageUrl = imageSwapHelper.swapImageSafely(image, null, owner.getId());
+            imageUrl = imageSwapHelper.swapImageSafely("clothes", image, null, owner.getId());
         }
 
         Clothes clothes = Clothes.builder()
@@ -85,7 +85,7 @@ public class ClothesServiceImpl implements ClothesService {
         clothes.updateNameAndType(request.name(), request.type());
 
         String newImageUrl = imageSwapHelper.swapImageSafely(
-            image, clothes.getImageUrl(), clothes.getOwner().getId());
+            "clothes", image, clothes.getImageUrl(), clothes.getOwner().getId());
 
         if (newImageUrl != null) {
             clothes.updateImageUrl(newImageUrl);
@@ -110,7 +110,7 @@ public class ClothesServiceImpl implements ClothesService {
         log.info("[Service] 의상 삭제 시작 - clothesId: {}", clothesId);
 
         Clothes clothes = clothesRepository.findById(clothesId)
-                .orElseThrow(() -> new ClothesNotFoundException(clothesId));
+            .orElseThrow(() -> new ClothesNotFoundException(clothesId));
 
         String oldImageUrl = clothes.getImageUrl();
 
@@ -122,7 +122,7 @@ public class ClothesServiceImpl implements ClothesService {
 
     }
 
-    private void validateClothesCreateRequest (ClothesCreateRequest request) {
+    private void validateClothesCreateRequest(ClothesCreateRequest request) {
         if (request.ownerId() == null) {
             throw new MissingRequiredFieldException("ownerId is null");
         }

--- a/src/main/java/org/ikuzo/otboo/domain/clothes/service/impl/ClothesServiceImpl.java
+++ b/src/main/java/org/ikuzo/otboo/domain/clothes/service/impl/ClothesServiceImpl.java
@@ -158,6 +158,18 @@ public class ClothesServiceImpl implements ClothesService {
         }
     }
 
+    private void replaceAttribute(Clothes clothes, List<ClothesAttributeDto> dtos) {
+
+        clothes.getAttributes().clear();
+
+        for (ClothesAttributeDto dto : dtos) {
+            if (dto == null) {
+                continue;
+            }
+            clothes.getAttributes().add(toClothesAttribute(clothes, dto));
+        }
+    }
+
     private ClothesAttribute toClothesAttribute(Clothes clothes, ClothesAttributeDto dto) {
         UUID defId = dto.definitionId();
         String value = dto.value() == null ? null : dto.value().trim();
@@ -189,17 +201,5 @@ public class ClothesServiceImpl implements ClothesService {
         List<AttributeOption> options = def.getOptions();
         return options == null ? List.of()
             : options.stream().map(AttributeOption::getValue).toList();
-    }
-
-    private void replaceAttribute(Clothes clothes, List<ClothesAttributeDto> dtos) {
-
-        clothes.getAttributes().clear();
-
-        for (ClothesAttributeDto dto : dtos) {
-            if (dto == null) {
-                continue;
-            }
-            clothes.getAttributes().add(toClothesAttribute(clothes, dto));
-        }
     }
 }

--- a/src/main/java/org/ikuzo/otboo/global/util/ImageSwapHelper.java
+++ b/src/main/java/org/ikuzo/otboo/global/util/ImageSwapHelper.java
@@ -4,9 +4,9 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import org.springframework.web.multipart.MultipartFile;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
+import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @Component
@@ -59,6 +59,25 @@ public class ImageSwapHelper {
                 }
             }
         );
+    }
+
+    public void deleteAfterCommit(String imageUrl, String context) {
+
+        if (imageUrl == null || imageUrl.isBlank()) {
+            return;
+        }
+
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            cleanupImageQuietly(imageUrl, "(활성 트랜잭션이 없어 즉시 삭제)" + context);
+            return;
+        }
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                cleanupImageQuietly(imageUrl, context);
+            }
+        });
     }
 
     private void cleanupImageQuietly(String imageUrl, String context) {

--- a/src/main/java/org/ikuzo/otboo/global/util/ImageSwapHelper.java
+++ b/src/main/java/org/ikuzo/otboo/global/util/ImageSwapHelper.java
@@ -22,12 +22,12 @@ public class ImageSwapHelper {
      * - 트랜잭션 커밋 성공 시: 기존 이미지 삭제
      * - 트랜잭션 롤백 시: 새 이미지 삭제
      */
-    public String swapImageSafely(MultipartFile newImage, String oldImageUrl, UUID ownerId) {
+    public String swapImageSafely(String folderName, MultipartFile newImage, String oldImageUrl, UUID ownerId) {
         if (newImage == null || newImage.isEmpty()) {
             return null;
         }
 
-        String folder = "clothes/" + ownerId + "/";
+        String folder = folderName + "/" + ownerId + "/";
         String newImageUrl = s3ImageStorage.uploadImage(newImage, folder);
 
         registerCleanupCallbacks(newImageUrl, oldImageUrl);


### PR DESCRIPTION
## 🔧 주요 작업 내용
> 이번 PR에서 작업한 내용을 작성해주세요
- [x] 의상 삭제 기능 구현
- [x] 트랜잭션 고려한 이미지 삭제 유틸 메서드 구현 

---

## ✅ 체크리스트
> PR이 다음 요구 사항을 충족하는지 확인해주세요
- [x] Postman으로 테스트 완료
- [x] 커밋 메시지 컨벤션 준수

---

## 📸 스크린샷
> Postman, Swagger UI 등을 통해 직접 확인한 테스트 내용을 첨부해주세요
<img width="2270" height="1263" alt="스크린샷 2025-09-14 212752" src="https://github.com/user-attachments/assets/f2f8ab35-3243-4703-8a1a-2a5854c81e47" />

---

## 📎 기타 참고 사항
- 추가 논의가 필요한 사항
- 관련 이슈, API 문서 링크 등

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 의상 삭제 API(DELETE /clothes/{id}) 추가: 성공 시 204 No Content 반환
- 개선
  - 삭제 시 연관 이미지의 트랜잭션 후 정리 지원으로 일관성·안정성 향상
  - 삭제 처리 전후 로깅 강화로 운영 가시성 개선
- 문서
  - API 문서에 의상 삭제 엔드포인트와 응답 코드(204, 404) 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->