### PR TITLE
[DM] DM 목록 조회

### DIFF
--- a/src/main/java/org/ikuzo/otboo/domain/directMessage/controller/DirectMessageController.java
+++ b/src/main/java/org/ikuzo/otboo/domain/directMessage/controller/DirectMessageController.java
@@ -1,0 +1,34 @@
+package org.ikuzo.otboo.domain.directMessage.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.ikuzo.otboo.domain.directMessage.dto.DirectMessageDto;
+import org.ikuzo.otboo.domain.directMessage.service.DirectMessageService;
+import org.ikuzo.otboo.global.dto.PageResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/direct-messages")
+@RequiredArgsConstructor
+public class DirectMessageController {
+
+    private final DirectMessageService directMessageService;
+
+    @GetMapping
+    public ResponseEntity<PageResponse<DirectMessageDto>> getDirectMessages(
+        @RequestParam UUID userId,
+        @RequestParam(required = false) Instant cursor,
+        @RequestParam(required = false) UUID idAfter,
+        @RequestParam int limit
+        ) {
+        PageResponse<DirectMessageDto> response = directMessageService.getDirectMessages(userId, cursor, idAfter, limit);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+}

--- a/src/main/java/org/ikuzo/otboo/domain/directMessage/repository/DirectMessageCustomRepository.java
+++ b/src/main/java/org/ikuzo/otboo/domain/directMessage/repository/DirectMessageCustomRepository.java
@@ -1,0 +1,12 @@
+package org.ikuzo.otboo.domain.directMessage.repository;
+
+import org.ikuzo.otboo.domain.directMessage.entity.DirectMessage;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+public interface DirectMessageCustomRepository {
+    List<DirectMessage>  getDirectMessages(UUID currentId, UUID userId, Instant cursor, UUID idAfter, int limit);
+    long countDirectMessages(UUID currentId, UUID userId);
+}

--- a/src/main/java/org/ikuzo/otboo/domain/directMessage/repository/DirectMessageCustomRepositoryImpl.java
+++ b/src/main/java/org/ikuzo/otboo/domain/directMessage/repository/DirectMessageCustomRepositoryImpl.java
@@ -1,0 +1,64 @@
+package org.ikuzo.otboo.domain.directMessage.repository;
+
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.ikuzo.otboo.domain.directMessage.entity.DirectMessage;
+import org.ikuzo.otboo.domain.directMessage.entity.QDirectMessage;
+import org.ikuzo.otboo.domain.user.entity.QUser;
+import org.springframework.stereotype.Repository;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class DirectMessageCustomRepositoryImpl implements DirectMessageCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<DirectMessage> getDirectMessages(UUID currentId, UUID userId, Instant cursor, UUID idAfter, int limit) {
+        QDirectMessage directMessage = QDirectMessage.directMessage;
+        QUser sender = new QUser("sender");
+        QUser receiver = new QUser("receiver");
+
+        JPAQuery<DirectMessage> query = queryFactory.selectFrom(directMessage);
+
+        query
+            .join(directMessage.sender, sender).fetchJoin()
+            .join(directMessage.receiver, receiver).fetchJoin()
+            .where(
+                (directMessage.sender.id.eq(userId).and(directMessage.receiver.id.eq(currentId)))
+                    .or(directMessage.sender.id.eq(currentId).and(directMessage.receiver.id.eq(userId)))
+            );
+
+        if (cursor != null && idAfter != null) {
+            query.where(
+                directMessage.createdAt.lt(cursor)
+                    .or(directMessage.createdAt.eq(cursor)
+                        .and(directMessage.id.lt(idAfter)))
+            );
+        }
+
+        return query
+            .orderBy(directMessage.createdAt.desc())
+            .limit(limit + 1)
+            .fetch();
+    }
+
+    @Override
+    public long countDirectMessages(UUID currentId, UUID userId) {
+        QDirectMessage directMessage = QDirectMessage.directMessage;
+
+        return queryFactory
+            .select(directMessage.count())
+            .from(directMessage)
+            .where(
+                (directMessage.sender.id.eq(userId).and(directMessage.receiver.id.eq(currentId)))
+                    .or(directMessage.sender.id.eq(currentId).and(directMessage.receiver.id.eq(userId)))
+            )
+            .fetchFirst();
+    }
+}

--- a/src/main/java/org/ikuzo/otboo/domain/directMessage/repository/DirectMessageRepository.java
+++ b/src/main/java/org/ikuzo/otboo/domain/directMessage/repository/DirectMessageRepository.java
@@ -7,5 +7,5 @@ import org.springframework.stereotype.Repository;
 import java.util.UUID;
 
 @Repository
-public interface DirectMessageRepository extends JpaRepository<DirectMessage, UUID> {
+public interface DirectMessageRepository extends JpaRepository<DirectMessage, UUID>, DirectMessageCustomRepository {
 }

--- a/src/main/java/org/ikuzo/otboo/domain/directMessage/service/DirectMessageService.java
+++ b/src/main/java/org/ikuzo/otboo/domain/directMessage/service/DirectMessageService.java
@@ -2,7 +2,13 @@ package org.ikuzo.otboo.domain.directMessage.service;
 
 import org.ikuzo.otboo.domain.directMessage.dto.DirectMessageCreateRequest;
 import org.ikuzo.otboo.domain.directMessage.dto.DirectMessageDto;
+import org.ikuzo.otboo.global.dto.PageResponse;
+
+import java.time.Instant;
+import java.util.UUID;
 
 public interface DirectMessageService {
     DirectMessageDto sendMessage(DirectMessageCreateRequest directMessageCreateRequest);
+
+    PageResponse<DirectMessageDto> getDirectMessages(UUID userId, Instant cursor, UUID idAfter, int limit);
 }

--- a/src/main/java/org/ikuzo/otboo/domain/directMessage/service/DirectMessageServiceImpl.java
+++ b/src/main/java/org/ikuzo/otboo/domain/directMessage/service/DirectMessageServiceImpl.java
@@ -9,12 +9,16 @@ import org.ikuzo.otboo.domain.directMessage.mapper.DirectMessageMapper;
 import org.ikuzo.otboo.domain.directMessage.repository.DirectMessageRepository;
 import org.ikuzo.otboo.domain.user.entity.User;
 import org.ikuzo.otboo.domain.user.repository.UserRepository;
+import org.ikuzo.otboo.global.dto.PageResponse;
 import org.ikuzo.otboo.global.event.message.MessageCreatedEvent;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -52,5 +56,55 @@ public class DirectMessageServiceImpl implements DirectMessageService {
         );
 
         return dto;
+    }
+
+    /**
+     * DM 목록 조회
+     *
+     * @param userId: 메세지를 보낼(수신자) userId
+     * @param cursor: 커서 (2025-09-10T09:47:14.318813Z)
+     * @param idAfter: 보조 커서 (0f6a481b-aee8-41ce-8aaf-2cf76434b395)
+     * @param limit: 사이즈
+     *
+     * @return PageResponse<DirectMessageDto>
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public PageResponse<DirectMessageDto> getDirectMessages(UUID userId, Instant cursor, UUID idAfter, int limit) {
+        // TODO: SpringSecurity 개발 후 securityContextHolder를 통해 접속 중인 유저 조회
+//        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+//        String email = authentication.getName();
+//        userRepository.findByEmail(email).orElseThrow(() -> new EntityNotFoundException("유저를 찾을 수 없습니다."));
+
+        UUID currentUserId = UUID.fromString("94728e4f-c0c6-40eb-99d1-f6bf07d2aee1");
+
+        List<DirectMessage> directMessages = directMessageRepository.getDirectMessages(currentUserId, userId, cursor, idAfter, limit);
+        List<DirectMessage> list = directMessages.size() > limit ? directMessages.subList(0, limit) : directMessages;
+        boolean hasNext = directMessages.size() > limit;
+        Instant nextCursor = null;
+        UUID nextIdAfter = null;
+
+        if (hasNext && !list.isEmpty()) {
+            DirectMessage last = list.get(list.size() - 1);
+            nextCursor = last.getCreatedAt();
+            nextIdAfter = last.getId();
+        }
+        String sortBy = "createdAt";
+        String sortDirection = "DESCENDING";
+        long totalCount = directMessageRepository.countDirectMessages(currentUserId, userId);
+
+        List<DirectMessageDto> content = list.stream()
+            .map(directMessageMapper::toDto)
+            .toList();
+
+        return new PageResponse<>(
+            content,
+            nextCursor,
+            nextIdAfter,
+            hasNext,
+            totalCount,
+            sortBy,
+            sortDirection
+        );
     }
 }


### PR DESCRIPTION
## 🔧 주요 작업 내용
> 이번 PR에서 작업한 내용을 작성해주세요
- [x] DirectMessage 목록 조회 API 추가 /api/direct-messages

---

## ✅ 체크리스트
> PR이 다음 요구 사항을 충족하는지 확인해주세요
- [x] 테스트 코드 작성 또는 수동 테스트 완료
- [x] 커밋 메시지 컨벤션 준수

---

## 📸 스크린샷
> Postman, Swagger UI 등을 통해 직접 확인한 테스트 내용을 첨부해주세요
- 정상 응답
  <img width="2748" height="2112" alt="image" src="https://github.com/user-attachments/assets/07547469-618e-4fad-9c50-0b2665414555" />
 
---

## 📎 기타 참고 사항
- 추가 논의가 필요한 사항
- 관련 이슈, API 문서 링크 등

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - Direct Message 조회 API(/api/direct-messages) 추가. userId·limit 필수, cursor·idAfter 옵션으로 시간+ID 기반 커서 페이지네이션 지원.
  - 최신순으로 메시지를 페이징해 반환하며, nextCursor/nextIdAfter, hasNext, 총 개수(total) 정보를 함께 제공.
  - 연속 스크롤 로딩과 과거 대화 탐색이 용이해져 모바일/웹에서 매끄러운 DM 히스토리 조회가 가능.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->