### PR TITLE
[Follow] 팔로우 서비스 로직 리팩토링

### DIFF
--- a/src/main/java/org/ikuzo/otboo/domain/follow/service/FollowServiceImpl.java
+++ b/src/main/java/org/ikuzo/otboo/domain/follow/service/FollowServiceImpl.java
@@ -12,6 +12,7 @@ import org.ikuzo.otboo.domain.follow.mapper.FollowMapper;
 import org.ikuzo.otboo.domain.follow.repository.FollowRepository;
 import org.ikuzo.otboo.domain.user.dto.UserSummary;
 import org.ikuzo.otboo.domain.user.entity.User;
+import org.ikuzo.otboo.domain.user.exception.UserNotFoundException;
 import org.ikuzo.otboo.domain.user.repository.UserRepository;
 import org.ikuzo.otboo.global.dto.PageResponse;
 import org.ikuzo.otboo.domain.follow.exception.FollowAlreadyException;
@@ -62,8 +63,8 @@ public class FollowServiceImpl implements FollowService {
             throw FollowAlreadyException.alreadyException(followerId);
         }
 
-        User follower = userRepository.findById(followerId).orElseThrow(() -> new EntityNotFoundException("팔로워를 찾을 수 없음"));
-        User followee = userRepository.findById(followeeId).orElseThrow(() -> new EntityNotFoundException("팔로이를 찾을 수 없음"));
+        User follower = userRepository.findById(followerId).orElseThrow(UserNotFoundException::new);
+        User followee = userRepository.findById(followeeId).orElseThrow(UserNotFoundException::new);
 
         Follow follow = Follow.builder()
             .follower(follower)


### PR DESCRIPTION
## 🔧 주요 작업 내용
> 이번 PR에서 작업한 내용을 작성해주세요
- [x] UserNotFoundException 예외 처리 리팩토링
- [x] SecurityContextHolder를 통해 로그인한 유저를 불러오도록 리팩토링 

---

## ✅ 체크리스트
> PR이 다음 요구 사항을 충족하는지 확인해주세요
- [x] 테스트 코드 작성 또는 수동 테스트 완료
- [x] 커밋 메시지 컨벤션 준수

---

## 📸 스크린샷
> Postman, Swagger UI 등을 통해 직접 확인한 테스트 내용을 첨부해주세요
- token 포함하여 요청 시 정상 응답
  <img width="2748" height="2112" alt="image" src="https://github.com/user-attachments/assets/7abd7eb4-7b34-4d4f-8d20-2b3b4e1f80b0" />
- 악의적으로 다른 사람의 팔로우를 취소하려고 하는 경우
  <img width="2748" height="2112" alt="image" src="https://github.com/user-attachments/assets/2b5bd5ae-e5f6-4f82-b6bf-4ace273b062f" />

---

## 📎 기타 참고 사항
- 추가 논의가 필요한 사항
- 관련 이슈, API 문서 링크 등

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 다이렉트 메시지 목록 페이지네이션 개선: nextCursor와 함께 nextIdAfter 제공으로 다음 페이지 탐색 정확도 향상.
  - 총 개수 계산 정확도 개선.

- 버그 수정
  - 하드코딩된 사용자 식별 제거, 실제 로그인 사용자 기반으로 조회/집계 수행.
  - 팔로우/언팔로우 권한 검증 강화로 비정상 취소 및 조회 문제 해결.
  - 존재하지 않는 사용자 상황에서 명확한 오류 응답 제공.

- 리팩터링
  - 서비스 전반의 인증 흐름 일원화 및 에러 처리 정비.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->