### PR TITLE
[AttributeDefinition] 의상 속성 목록 조회

### DIFF
--- a/src/main/java/org/ikuzo/otboo/domain/clothes/controller/ClothesAttributeDefController.java
+++ b/src/main/java/org/ikuzo/otboo/domain/clothes/controller/ClothesAttributeDefController.java
@@ -1,6 +1,10 @@
 package org.ikuzo.otboo.domain.clothes.controller;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -8,15 +12,19 @@ import org.ikuzo.otboo.domain.clothes.controller.api.ClothesAttributeDefApi;
 import org.ikuzo.otboo.domain.clothes.dto.ClothesAttributeDefDto;
 import org.ikuzo.otboo.domain.clothes.dto.request.ClothesAttributeDefCreateRequest;
 import org.ikuzo.otboo.domain.clothes.dto.request.ClothesAttributeDefUpdateRequest;
+import org.ikuzo.otboo.domain.clothes.enums.AttributeDefSortBy;
+import org.ikuzo.otboo.domain.clothes.enums.AttributeDefSortDirection;
 import org.ikuzo.otboo.domain.clothes.service.ClothesAttributeDefService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
@@ -26,6 +34,29 @@ import org.springframework.web.bind.annotation.RestController;
 public class ClothesAttributeDefController implements ClothesAttributeDefApi {
 
     private final ClothesAttributeDefService clothesAttributeDefService;
+
+    @GetMapping
+    @Override
+    public ResponseEntity<List<ClothesAttributeDefDto>> getWithCursor(
+        @RequestParam AttributeDefSortBy sortBy,
+        @RequestParam AttributeDefSortDirection sortDirection,
+        @RequestParam(required = false, defaultValue = "") String keywordLike,
+        @RequestParam(required = false) String cursor,
+        @RequestParam(required = false) UUID idAfter,
+        @RequestParam(defaultValue = "40") @Min(1) @Max(100) int limit
+    ) {
+        log.info("[Controller] 속성 목록 조회 요청 - sortBy: {}, sortDirection: {}, keywordLike: {}",
+            sortBy, sortDirection, Objects.equals(keywordLike, "") ? "공백" :  keywordLike);
+
+        List<ClothesAttributeDefDto> response = clothesAttributeDefService.getWithCursor(
+            cursor, idAfter, limit, sortBy, sortDirection, keywordLike
+        );
+
+        log.info("[Controller] 속성 목록 조회 완료 - sortBy: {}, sortDirection: {}, keywordLike: {}",
+            sortBy, sortDirection, Objects.equals(keywordLike, "") ? "공백" :  keywordLike);
+
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
 
     @PostMapping
     @Override

--- a/src/main/java/org/ikuzo/otboo/domain/clothes/controller/ClothesAttributeDefController.java
+++ b/src/main/java/org/ikuzo/otboo/domain/clothes/controller/ClothesAttributeDefController.java
@@ -35,7 +35,7 @@ public class ClothesAttributeDefController implements ClothesAttributeDefApi {
 
     @GetMapping
     @Override
-    public ResponseEntity<List<ClothesAttributeDefDto>> getWithCursor(
+    public ResponseEntity<List<ClothesAttributeDefDto>> getList(
         @RequestParam AttributeDefSortBy sortBy,
         @RequestParam AttributeDefSortDirection sortDirection,
         @RequestParam(required = false, defaultValue = "") String keywordLike
@@ -43,7 +43,7 @@ public class ClothesAttributeDefController implements ClothesAttributeDefApi {
         log.info("[Controller] 속성 목록 조회 요청 - sortBy: {}, sortDirection: {}, keywordLike: {}",
             sortBy, sortDirection, Objects.equals(keywordLike, "") ? "공백" : keywordLike);
 
-        List<ClothesAttributeDefDto> response = clothesAttributeDefService.getWithCursor(
+        List<ClothesAttributeDefDto> response = clothesAttributeDefService.getList(
             sortBy, sortDirection, keywordLike
         );
 

--- a/src/main/java/org/ikuzo/otboo/domain/clothes/controller/ClothesAttributeDefController.java
+++ b/src/main/java/org/ikuzo/otboo/domain/clothes/controller/ClothesAttributeDefController.java
@@ -1,8 +1,6 @@
 package org.ikuzo.otboo.domain.clothes.controller;
 
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
@@ -40,20 +38,17 @@ public class ClothesAttributeDefController implements ClothesAttributeDefApi {
     public ResponseEntity<List<ClothesAttributeDefDto>> getWithCursor(
         @RequestParam AttributeDefSortBy sortBy,
         @RequestParam AttributeDefSortDirection sortDirection,
-        @RequestParam(required = false, defaultValue = "") String keywordLike,
-        @RequestParam(required = false) String cursor,
-        @RequestParam(required = false) UUID idAfter,
-        @RequestParam(defaultValue = "40") @Min(1) @Max(100) int limit
+        @RequestParam(required = false, defaultValue = "") String keywordLike
     ) {
         log.info("[Controller] 속성 목록 조회 요청 - sortBy: {}, sortDirection: {}, keywordLike: {}",
-            sortBy, sortDirection, Objects.equals(keywordLike, "") ? "공백" :  keywordLike);
+            sortBy, sortDirection, Objects.equals(keywordLike, "") ? "공백" : keywordLike);
 
         List<ClothesAttributeDefDto> response = clothesAttributeDefService.getWithCursor(
-            cursor, idAfter, limit, sortBy, sortDirection, keywordLike
+            sortBy, sortDirection, keywordLike
         );
 
         log.info("[Controller] 속성 목록 조회 완료 - sortBy: {}, sortDirection: {}, keywordLike: {}",
-            sortBy, sortDirection, Objects.equals(keywordLike, "") ? "공백" :  keywordLike);
+            sortBy, sortDirection, Objects.equals(keywordLike, "") ? "공백" : keywordLike);
 
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }

--- a/src/main/java/org/ikuzo/otboo/domain/clothes/controller/api/ClothesAttributeDefApi.java
+++ b/src/main/java/org/ikuzo/otboo/domain/clothes/controller/api/ClothesAttributeDefApi.java
@@ -7,8 +7,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 import java.util.List;
 import java.util.UUID;
 import org.ikuzo.otboo.domain.clothes.dto.ClothesAttributeDefDto;
@@ -47,10 +45,7 @@ public interface ClothesAttributeDefApi {
     ResponseEntity<List<ClothesAttributeDefDto>> getWithCursor(
         @RequestParam AttributeDefSortBy sortBy,
         @RequestParam AttributeDefSortDirection sortDirection,
-        @RequestParam(required = false) String keywordLike,
-        @RequestParam(required = false) String cursor,
-        @RequestParam(required = false) UUID idAfter,
-        @RequestParam(defaultValue = "40") @Min(1) @Max(100) int limit
+        @RequestParam(required = false, defaultValue = "") String keywordLike
     );
 
     @Operation(summary = "의상 속성 정의 등록")

--- a/src/main/java/org/ikuzo/otboo/domain/clothes/controller/api/ClothesAttributeDefApi.java
+++ b/src/main/java/org/ikuzo/otboo/domain/clothes/controller/api/ClothesAttributeDefApi.java
@@ -1,6 +1,7 @@
 package org.ikuzo.otboo.domain.clothes.controller.api;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -30,7 +31,7 @@ public interface ClothesAttributeDefApi {
             description = "의상 속성 정의 목록 조회 성공",
             content = @Content(
                 mediaType = "*/*",
-                schema = @Schema(implementation = ClothesAttributeDefDto.class)
+                array = @ArraySchema(schema = @Schema(implementation = ClothesAttributeDefDto.class))
             )
         ),
         @ApiResponse(

--- a/src/main/java/org/ikuzo/otboo/domain/clothes/controller/api/ClothesAttributeDefApi.java
+++ b/src/main/java/org/ikuzo/otboo/domain/clothes/controller/api/ClothesAttributeDefApi.java
@@ -7,17 +7,51 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import java.util.List;
 import java.util.UUID;
 import org.ikuzo.otboo.domain.clothes.dto.ClothesAttributeDefDto;
 import org.ikuzo.otboo.domain.clothes.dto.request.ClothesAttributeDefCreateRequest;
 import org.ikuzo.otboo.domain.clothes.dto.request.ClothesAttributeDefUpdateRequest;
+import org.ikuzo.otboo.domain.clothes.enums.AttributeDefSortBy;
+import org.ikuzo.otboo.domain.clothes.enums.AttributeDefSortDirection;
 import org.ikuzo.otboo.global.exception.ErrorResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "의상 속성 정의", description = "의상 속성 정의 관련 API")
 public interface ClothesAttributeDefApi {
+
+    @Operation(summary = "의상 속성 정의 목록 조회")
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "의상 속성 정의 목록 조회 성공",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ClothesAttributeDefDto.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "의상 속성 정의 목록 조회 실패",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class)
+            )
+        )
+    })
+    ResponseEntity<List<ClothesAttributeDefDto>> getWithCursor(
+        @RequestParam AttributeDefSortBy sortBy,
+        @RequestParam AttributeDefSortDirection sortDirection,
+        @RequestParam(required = false) String keywordLike,
+        @RequestParam(required = false) String cursor,
+        @RequestParam(required = false) UUID idAfter,
+        @RequestParam(defaultValue = "40") @Min(1) @Max(100) int limit
+    );
 
     @Operation(summary = "의상 속성 정의 등록")
     @ApiResponses({

--- a/src/main/java/org/ikuzo/otboo/domain/clothes/controller/api/ClothesAttributeDefApi.java
+++ b/src/main/java/org/ikuzo/otboo/domain/clothes/controller/api/ClothesAttributeDefApi.java
@@ -43,7 +43,7 @@ public interface ClothesAttributeDefApi {
             )
         )
     })
-    ResponseEntity<List<ClothesAttributeDefDto>> getWithCursor(
+    ResponseEntity<List<ClothesAttributeDefDto>> getList(
         @RequestParam AttributeDefSortBy sortBy,
         @RequestParam AttributeDefSortDirection sortDirection,
         @RequestParam(required = false, defaultValue = "") String keywordLike

--- a/src/main/java/org/ikuzo/otboo/domain/clothes/dto/ClothesDto.java
+++ b/src/main/java/org/ikuzo/otboo/domain/clothes/dto/ClothesDto.java
@@ -2,7 +2,7 @@ package org.ikuzo.otboo.domain.clothes.dto;
 
 import java.util.List;
 import java.util.UUID;
-import org.ikuzo.otboo.domain.clothes.entity.ClothesType;
+import org.ikuzo.otboo.domain.clothes.enums.ClothesType;
 
 public record ClothesDto(
     UUID id,

--- a/src/main/java/org/ikuzo/otboo/domain/clothes/dto/request/ClothesCreateRequest.java
+++ b/src/main/java/org/ikuzo/otboo/domain/clothes/dto/request/ClothesCreateRequest.java
@@ -7,7 +7,7 @@ import jakarta.validation.constraints.Size;
 import java.util.List;
 import java.util.UUID;
 import org.ikuzo.otboo.domain.clothes.dto.ClothesAttributeDto;
-import org.ikuzo.otboo.domain.clothes.entity.ClothesType;
+import org.ikuzo.otboo.domain.clothes.enums.ClothesType;
 
 public record ClothesCreateRequest(
 

--- a/src/main/java/org/ikuzo/otboo/domain/clothes/dto/request/ClothesUpdateRequest.java
+++ b/src/main/java/org/ikuzo/otboo/domain/clothes/dto/request/ClothesUpdateRequest.java
@@ -2,7 +2,7 @@ package org.ikuzo.otboo.domain.clothes.dto.request;
 
 import java.util.List;
 import org.ikuzo.otboo.domain.clothes.dto.ClothesAttributeDto;
-import org.ikuzo.otboo.domain.clothes.entity.ClothesType;
+import org.ikuzo.otboo.domain.clothes.enums.ClothesType;
 
 public record ClothesUpdateRequest(
     String name,

--- a/src/main/java/org/ikuzo/otboo/domain/clothes/entity/Clothes.java
+++ b/src/main/java/org/ikuzo/otboo/domain/clothes/entity/Clothes.java
@@ -17,6 +17,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.ikuzo.otboo.domain.clothes.enums.ClothesType;
 import org.ikuzo.otboo.domain.user.entity.User;
 import org.ikuzo.otboo.global.base.BaseUpdatableEntity;
 

--- a/src/main/java/org/ikuzo/otboo/domain/clothes/enums/AttributeDefSortBy.java
+++ b/src/main/java/org/ikuzo/otboo/domain/clothes/enums/AttributeDefSortBy.java
@@ -1,0 +1,6 @@
+package org.ikuzo.otboo.domain.clothes.enums;
+
+public enum AttributeDefSortBy {
+    createdAt,
+    name
+}

--- a/src/main/java/org/ikuzo/otboo/domain/clothes/enums/AttributeDefSortDirection.java
+++ b/src/main/java/org/ikuzo/otboo/domain/clothes/enums/AttributeDefSortDirection.java
@@ -1,0 +1,6 @@
+package org.ikuzo.otboo.domain.clothes.enums;
+
+public enum AttributeDefSortDirection {
+    ASCENDING,
+    DESCENDING
+}

--- a/src/main/java/org/ikuzo/otboo/domain/clothes/enums/ClothesType.java
+++ b/src/main/java/org/ikuzo/otboo/domain/clothes/enums/ClothesType.java
@@ -1,4 +1,4 @@
-package org.ikuzo.otboo.domain.clothes.entity;
+package org.ikuzo.otboo.domain.clothes.enums;
 
 public enum ClothesType {
     TOP,

--- a/src/main/java/org/ikuzo/otboo/domain/clothes/repository/ClothesAttributeDefRepository.java
+++ b/src/main/java/org/ikuzo/otboo/domain/clothes/repository/ClothesAttributeDefRepository.java
@@ -6,7 +6,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ClothesAttributeDefRepository extends JpaRepository<ClothesAttributeDef, UUID> {
+public interface ClothesAttributeDefRepository extends JpaRepository<ClothesAttributeDef, UUID>,
+    ClothesAttributeDefRepositoryCustom {
 
     boolean existsByName(String name);
 

--- a/src/main/java/org/ikuzo/otboo/domain/clothes/repository/ClothesAttributeDefRepositoryCustom.java
+++ b/src/main/java/org/ikuzo/otboo/domain/clothes/repository/ClothesAttributeDefRepositoryCustom.java
@@ -1,7 +1,6 @@
 package org.ikuzo.otboo.domain.clothes.repository;
 
 import java.util.List;
-import java.util.UUID;
 import org.ikuzo.otboo.domain.clothes.entity.ClothesAttributeDef;
 import org.ikuzo.otboo.domain.clothes.enums.AttributeDefSortBy;
 import org.ikuzo.otboo.domain.clothes.enums.AttributeDefSortDirection;
@@ -9,9 +8,6 @@ import org.ikuzo.otboo.domain.clothes.enums.AttributeDefSortDirection;
 public interface ClothesAttributeDefRepositoryCustom {
 
     List<ClothesAttributeDef> findAttributeDefWithCursor (
-        String cursor,
-        UUID idAfter,
-        int limit,
         AttributeDefSortBy sortBy,
         AttributeDefSortDirection direction,
         String keywordLike

--- a/src/main/java/org/ikuzo/otboo/domain/clothes/repository/ClothesAttributeDefRepositoryCustom.java
+++ b/src/main/java/org/ikuzo/otboo/domain/clothes/repository/ClothesAttributeDefRepositoryCustom.java
@@ -1,0 +1,19 @@
+package org.ikuzo.otboo.domain.clothes.repository;
+
+import java.util.List;
+import java.util.UUID;
+import org.ikuzo.otboo.domain.clothes.entity.ClothesAttributeDef;
+import org.ikuzo.otboo.domain.clothes.enums.AttributeDefSortBy;
+import org.ikuzo.otboo.domain.clothes.enums.AttributeDefSortDirection;
+
+public interface ClothesAttributeDefRepositoryCustom {
+
+    List<ClothesAttributeDef> findAttributeDefWithCursor (
+        String cursor,
+        UUID idAfter,
+        int limit,
+        AttributeDefSortBy sortBy,
+        AttributeDefSortDirection direction,
+        String keywordLike
+    );
+}

--- a/src/main/java/org/ikuzo/otboo/domain/clothes/repository/impl/ClothesAttributeDefRepositoryImpl.java
+++ b/src/main/java/org/ikuzo/otboo/domain/clothes/repository/impl/ClothesAttributeDefRepositoryImpl.java
@@ -1,0 +1,125 @@
+package org.ikuzo.otboo.domain.clothes.repository.impl;
+
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.ikuzo.otboo.domain.clothes.entity.ClothesAttributeDef;
+import org.ikuzo.otboo.domain.clothes.entity.QClothesAttributeDef;
+import org.ikuzo.otboo.domain.clothes.enums.AttributeDefSortBy;
+import org.ikuzo.otboo.domain.clothes.enums.AttributeDefSortDirection;
+import org.ikuzo.otboo.domain.clothes.repository.ClothesAttributeDefRepositoryCustom;
+import org.springframework.stereotype.Repository;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class ClothesAttributeDefRepositoryImpl implements ClothesAttributeDefRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<ClothesAttributeDef> findAttributeDefWithCursor(
+        String cursor,
+        UUID idAfter,
+        int limit,
+        AttributeDefSortBy sortBy,
+        AttributeDefSortDirection direction,
+        String keywordLike
+    ) {
+        QClothesAttributeDef d = QClothesAttributeDef.clothesAttributeDef;
+
+        boolean asc = (direction == AttributeDefSortDirection.ASCENDING);
+
+        return queryFactory
+            .selectFrom(d)
+            .where(
+                likeKeyword(d, keywordLike),
+                cursorCondition(d, cursor, idAfter, sortBy, asc)
+            )
+            .orderBy(orderBy(d, sortBy, asc))
+            .limit(limit + 1)
+            .fetch();
+    }
+
+    private BooleanExpression likeKeyword(
+        QClothesAttributeDef d, String keywordLike
+    ) {
+        if (keywordLike == null || keywordLike.isBlank()) {
+            return null;
+        }
+        return d.name.containsIgnoreCase(keywordLike.trim());
+    }
+
+    private BooleanExpression cursorCondition(
+        QClothesAttributeDef d,
+        String cursor,
+        UUID idAfter,
+        AttributeDefSortBy sortBy,
+        boolean asc
+    ) {
+        return switch (sortBy) {
+            case createdAt -> cursorByCreatedAt(d, cursor, idAfter, asc);
+            case name -> cursorByName(d, cursor, idAfter, asc);
+        };
+    }
+
+    private BooleanExpression cursorByCreatedAt(
+        QClothesAttributeDef d, String cursor, UUID idAfter, boolean asc
+    ) {
+        if (cursor == null || cursor.isBlank()) {
+            return null;
+        }
+
+        final Instant c;
+        try {
+            c = Instant.parse(cursor.trim());
+        } catch (DateTimeParseException e) {
+            log.warn("잘못된 createdAt 커서 포맷: {}", cursor);
+            return null;
+        }
+
+        BooleanExpression primary = asc ? d.createdAt.gt(c) : d.createdAt.lt(c);
+        if (idAfter == null) {
+            return primary;
+        }
+
+        BooleanExpression tie = asc ? d.id.gt(idAfter) : d.id.lt(idAfter);
+
+        return primary.or(d.createdAt.eq(c).and(tie));
+    }
+
+    private BooleanExpression cursorByName(
+        QClothesAttributeDef d, String cursor, UUID idAfter, boolean asc
+    ) {
+        if (cursor == null || cursor.isBlank()) {
+            return null;
+        }
+
+        String c = cursor.trim();
+        BooleanExpression primary = asc ? d.name.gt(c) : d.name.lt(c);
+        if (idAfter == null) {
+            return primary;
+        }
+
+        BooleanExpression tie = asc ? d.id.gt(idAfter) : d.id.lt(idAfter);
+
+        return primary.or(d.name.eq(c).and(tie));
+    }
+
+    private OrderSpecifier<?>[] orderBy(
+        QClothesAttributeDef d, AttributeDefSortBy sortBy, boolean asc
+    ) {
+        OrderSpecifier<?> primary = (sortBy == AttributeDefSortBy.createdAt)
+            ? (asc ? d.createdAt.asc() : d.createdAt.desc())
+            : (asc ? d.name.asc() : d.name.desc());
+        OrderSpecifier<?> tie = asc ? d.id.asc() : d.id.desc();
+
+        return new OrderSpecifier<?>[]{primary, tie};
+    }
+}

--- a/src/main/java/org/ikuzo/otboo/domain/clothes/repository/impl/ClothesAttributeDefRepositoryImpl.java
+++ b/src/main/java/org/ikuzo/otboo/domain/clothes/repository/impl/ClothesAttributeDefRepositoryImpl.java
@@ -32,9 +32,7 @@ public class ClothesAttributeDefRepositoryImpl implements ClothesAttributeDefRep
 
         return queryFactory
             .selectFrom(d)
-            .where(
-                likeKeyword(d, keywordLike)
-            )
+            .where(likeKeyword(d, keywordLike))
             .orderBy(orderBy(d, sortBy, asc))
             .fetch();
     }

--- a/src/main/java/org/ikuzo/otboo/domain/clothes/repository/impl/ClothesAttributeDefRepositoryImpl.java
+++ b/src/main/java/org/ikuzo/otboo/domain/clothes/repository/impl/ClothesAttributeDefRepositoryImpl.java
@@ -3,10 +3,7 @@ package org.ikuzo.otboo.domain.clothes.repository.impl;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.time.Instant;
-import java.time.format.DateTimeParseException;
 import java.util.List;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.ikuzo.otboo.domain.clothes.entity.ClothesAttributeDef;
@@ -25,9 +22,6 @@ public class ClothesAttributeDefRepositoryImpl implements ClothesAttributeDefRep
 
     @Override
     public List<ClothesAttributeDef> findAttributeDefWithCursor(
-        String cursor,
-        UUID idAfter,
-        int limit,
         AttributeDefSortBy sortBy,
         AttributeDefSortDirection direction,
         String keywordLike
@@ -39,11 +33,9 @@ public class ClothesAttributeDefRepositoryImpl implements ClothesAttributeDefRep
         return queryFactory
             .selectFrom(d)
             .where(
-                likeKeyword(d, keywordLike),
-                cursorCondition(d, cursor, idAfter, sortBy, asc)
+                likeKeyword(d, keywordLike)
             )
             .orderBy(orderBy(d, sortBy, asc))
-            .limit(limit + 1)
             .fetch();
     }
 
@@ -54,62 +46,6 @@ public class ClothesAttributeDefRepositoryImpl implements ClothesAttributeDefRep
             return null;
         }
         return d.name.containsIgnoreCase(keywordLike.trim());
-    }
-
-    private BooleanExpression cursorCondition(
-        QClothesAttributeDef d,
-        String cursor,
-        UUID idAfter,
-        AttributeDefSortBy sortBy,
-        boolean asc
-    ) {
-        return switch (sortBy) {
-            case createdAt -> cursorByCreatedAt(d, cursor, idAfter, asc);
-            case name -> cursorByName(d, cursor, idAfter, asc);
-        };
-    }
-
-    private BooleanExpression cursorByCreatedAt(
-        QClothesAttributeDef d, String cursor, UUID idAfter, boolean asc
-    ) {
-        if (cursor == null || cursor.isBlank()) {
-            return null;
-        }
-
-        final Instant c;
-        try {
-            c = Instant.parse(cursor.trim());
-        } catch (DateTimeParseException e) {
-            log.warn("잘못된 createdAt 커서 포맷: {}", cursor);
-            return null;
-        }
-
-        BooleanExpression primary = asc ? d.createdAt.gt(c) : d.createdAt.lt(c);
-        if (idAfter == null) {
-            return primary;
-        }
-
-        BooleanExpression tie = asc ? d.id.gt(idAfter) : d.id.lt(idAfter);
-
-        return primary.or(d.createdAt.eq(c).and(tie));
-    }
-
-    private BooleanExpression cursorByName(
-        QClothesAttributeDef d, String cursor, UUID idAfter, boolean asc
-    ) {
-        if (cursor == null || cursor.isBlank()) {
-            return null;
-        }
-
-        String c = cursor.trim();
-        BooleanExpression primary = asc ? d.name.gt(c) : d.name.lt(c);
-        if (idAfter == null) {
-            return primary;
-        }
-
-        BooleanExpression tie = asc ? d.id.gt(idAfter) : d.id.lt(idAfter);
-
-        return primary.or(d.name.eq(c).and(tie));
     }
 
     private OrderSpecifier<?>[] orderBy(

--- a/src/main/java/org/ikuzo/otboo/domain/clothes/repository/impl/ClothesRepositoryImpl.java
+++ b/src/main/java/org/ikuzo/otboo/domain/clothes/repository/impl/ClothesRepositoryImpl.java
@@ -1,4 +1,4 @@
-package org.ikuzo.otboo.domain.clothes.repository;
+package org.ikuzo.otboo.domain.clothes.repository.impl;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -9,8 +9,9 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.ikuzo.otboo.domain.clothes.entity.Clothes;
-import org.ikuzo.otboo.domain.clothes.entity.ClothesType;
+import org.ikuzo.otboo.domain.clothes.enums.ClothesType;
 import org.ikuzo.otboo.domain.clothes.entity.QClothes;
+import org.ikuzo.otboo.domain.clothes.repository.ClothesRepositoryCustom;
 import org.springframework.stereotype.Repository;
 
 @Slf4j

--- a/src/main/java/org/ikuzo/otboo/domain/clothes/service/ClothesAttributeDefService.java
+++ b/src/main/java/org/ikuzo/otboo/domain/clothes/service/ClothesAttributeDefService.java
@@ -1,9 +1,12 @@
 package org.ikuzo.otboo.domain.clothes.service;
 
+import java.util.List;
 import java.util.UUID;
 import org.ikuzo.otboo.domain.clothes.dto.request.ClothesAttributeDefCreateRequest;
 import org.ikuzo.otboo.domain.clothes.dto.ClothesAttributeDefDto;
 import org.ikuzo.otboo.domain.clothes.dto.request.ClothesAttributeDefUpdateRequest;
+import org.ikuzo.otboo.domain.clothes.enums.AttributeDefSortBy;
+import org.ikuzo.otboo.domain.clothes.enums.AttributeDefSortDirection;
 
 public interface ClothesAttributeDefService {
 
@@ -12,4 +15,13 @@ public interface ClothesAttributeDefService {
     ClothesAttributeDefDto update(UUID definitionId, ClothesAttributeDefUpdateRequest request);
 
     void delete(UUID definitionId);
+
+    List<ClothesAttributeDefDto> getWithCursor(
+        String cursor,
+        UUID idAfter,
+        int limit,
+        AttributeDefSortBy sortBy,
+        AttributeDefSortDirection sortDirection,
+        String keywordLike
+    );
 }

--- a/src/main/java/org/ikuzo/otboo/domain/clothes/service/ClothesAttributeDefService.java
+++ b/src/main/java/org/ikuzo/otboo/domain/clothes/service/ClothesAttributeDefService.java
@@ -17,9 +17,6 @@ public interface ClothesAttributeDefService {
     void delete(UUID definitionId);
 
     List<ClothesAttributeDefDto> getWithCursor(
-        String cursor,
-        UUID idAfter,
-        int limit,
         AttributeDefSortBy sortBy,
         AttributeDefSortDirection sortDirection,
         String keywordLike

--- a/src/main/java/org/ikuzo/otboo/domain/clothes/service/ClothesAttributeDefService.java
+++ b/src/main/java/org/ikuzo/otboo/domain/clothes/service/ClothesAttributeDefService.java
@@ -16,7 +16,7 @@ public interface ClothesAttributeDefService {
 
     void delete(UUID definitionId);
 
-    List<ClothesAttributeDefDto> getWithCursor(
+    List<ClothesAttributeDefDto> getList(
         AttributeDefSortBy sortBy,
         AttributeDefSortDirection sortDirection,
         String keywordLike

--- a/src/main/java/org/ikuzo/otboo/domain/clothes/service/impl/ClothesAttributeDefServiceImpl.java
+++ b/src/main/java/org/ikuzo/otboo/domain/clothes/service/impl/ClothesAttributeDefServiceImpl.java
@@ -38,38 +38,23 @@ public class ClothesAttributeDefServiceImpl implements ClothesAttributeDefServic
     @Transactional(readOnly = true)
     @Override
     public List<ClothesAttributeDefDto> getWithCursor(
-        String cursor,
-        UUID idAfter,
-        int limit,
         AttributeDefSortBy sortBy,
         AttributeDefSortDirection sortDirection,
         String keywordLike
     ) {
         log.info("[Service] 속성 목록 조회 시작 - sortBy: {}, sortDirection: {}, keywordLike: {}",
-            sortBy, sortDirection, Objects.equals(keywordLike, "") ? "공백" :  keywordLike);
+            sortBy, sortDirection, Objects.equals(keywordLike, "") ? "공백" : keywordLike);
 
         String normalizeKeyword = normalizeKeyword(keywordLike);
 
-        List<ClothesAttributeDef> result = clothesAttributeDefRepository.findAttributeDefWithCursor(
-            cursor, idAfter, limit, sortBy, sortDirection, normalizeKeyword
+        List<ClothesAttributeDef> data = clothesAttributeDefRepository.findAttributeDefWithCursor(
+            sortBy, sortDirection, normalizeKeyword
         );
 
-        boolean hasNext = result.size() > limit;
-        List<ClothesAttributeDef> content = hasNext ? result.subList(0, limit) : result;
+        log.info("[Service] 속성 목록 조회 완료 - sortBy: {}, sortDirection: {}, keywordLike: {}",
+            sortBy, sortDirection, Objects.equals(keywordLike, "") ? "공백" : keywordLike);
 
-        Object nextCursor = null;
-        UUID nextIdAfter = null;
-        if (hasNext && !content.isEmpty()) {
-            ClothesAttributeDef last = content.get(content.size() - 1);
-            nextCursor =
-                (sortBy == AttributeDefSortBy.createdAt) ? last.getCreatedAt() : last.getName();
-            nextIdAfter = last.getId();
-        }
-
-        log.info("[Service] 속성 목록 조회 시작 - sortBy: {}, sortDirection: {}, keywordLike: {}",
-            sortBy, sortDirection, Objects.equals(keywordLike, "") ? "공백" :  keywordLike);
-
-        return content.stream()
+        return data.stream()
             .map(mapper::toDto)
             .toList();
     }

--- a/src/main/java/org/ikuzo/otboo/domain/clothes/service/impl/ClothesAttributeDefServiceImpl.java
+++ b/src/main/java/org/ikuzo/otboo/domain/clothes/service/impl/ClothesAttributeDefServiceImpl.java
@@ -37,7 +37,7 @@ public class ClothesAttributeDefServiceImpl implements ClothesAttributeDefServic
     @PreAuthorize("hasRole('ADMIN')")
     @Transactional(readOnly = true)
     @Override
-    public List<ClothesAttributeDefDto> getWithCursor(
+    public List<ClothesAttributeDefDto> getList(
         AttributeDefSortBy sortBy,
         AttributeDefSortDirection sortDirection,
         String keywordLike

--- a/src/main/java/org/ikuzo/otboo/global/dto/PageResponse.java
+++ b/src/main/java/org/ikuzo/otboo/global/dto/PageResponse.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.UUID;
 
 public record PageResponse<T>(
-    List<T> content,
+    List<T> data,
     Object nextCursor,
     UUID nextIdAfter,
     boolean hasNext,


### PR DESCRIPTION
## 🔧 주요 작업 내용
> 이번 PR에서 작업한 내용을 작성해주세요
- [x] 의상 속성 목록 조회 기능 구현

---

## ✅ 체크리스트
> PR이 다음 요구 사항을 충족하는지 확인해주세요
- [x] 로컬 환경에서 실제 테스트 완료
- [x] 커밋 메시지 컨벤션 준수

---

## 📸 스크린샷
> Postman, Swagger UI 등을 통해 직접 확인한 테스트 내용을 첨부해주세요
<img width="2525" height="1234" alt="image" src="https://github.com/user-attachments/assets/6960dc27-5a06-4fb0-a633-4a1056760f41" />

---

## 📎 기타 참고 사항
- 추가 논의가 필요한 사항
- 관련 이슈, API 문서 링크 등

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 의류 속성 정의 조회용 GET 엔드포인트 추가: 정렬 기준/방향 지정 및 선택적 키워드 필터로 관리자가 정렬된 목록을 조회 가능.
- 리팩터
  - ClothesType을 enums로 이동해 타입 사용 정리.
  - 정렬 관련 enum 추가로 정렬 일관성 향상.
  - 리포지토리 구조 확장 및 구현 추가로 커서 기반 조회 및 필터링 지원 강화.
  - API 응답 스키마: PageResponse의 필드명 content → data로 변경.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->