### PR TITLE
[Auth] 토큰 재발급

### DIFF
--- a/src/main/java/org/ikuzo/otboo/domain/auth/controller/AuthController.java
+++ b/src/main/java/org/ikuzo/otboo/domain/auth/controller/AuthController.java
@@ -1,0 +1,44 @@
+package org.ikuzo.otboo.domain.auth.controller;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.ikuzo.otboo.domain.auth.dto.JwtInformation;
+import org.ikuzo.otboo.domain.auth.service.AuthService;
+import org.ikuzo.otboo.global.security.JwtDto;
+import org.ikuzo.otboo.global.security.JwtTokenProvider;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final AuthService authService;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @PostMapping("/refresh")
+    public ResponseEntity<JwtDto> refresh(@CookieValue("REFRESH_TOKEN") String refreshToken,
+        HttpServletResponse response) {
+        log.info("토큰 리프레시 요청");
+        JwtInformation refreshResult = authService.refreshToken(refreshToken);
+        Cookie refreshCookie = jwtTokenProvider.genereateRefreshTokenCookie(
+            refreshResult.refreshToken());
+        response.addCookie(refreshCookie);
+
+        JwtDto body = new JwtDto(
+            refreshResult.userDto(),
+            refreshResult.accessToken()
+        );
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(body);
+    }
+}

--- a/src/main/java/org/ikuzo/otboo/domain/auth/controller/AuthController.java
+++ b/src/main/java/org/ikuzo/otboo/domain/auth/controller/AuthController.java
@@ -29,7 +29,7 @@ public class AuthController {
         HttpServletResponse response) {
         log.info("토큰 리프레시 요청");
         JwtInformation refreshResult = authService.refreshToken(refreshToken);
-        Cookie refreshCookie = jwtTokenProvider.genereateRefreshTokenCookie(
+        Cookie refreshCookie = jwtTokenProvider.generateRefreshTokenCookie(
             refreshResult.refreshToken());
         response.addCookie(refreshCookie);
 

--- a/src/main/java/org/ikuzo/otboo/domain/auth/controller/AuthController.java
+++ b/src/main/java/org/ikuzo/otboo/domain/auth/controller/AuthController.java
@@ -6,7 +6,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.ikuzo.otboo.domain.auth.dto.JwtInformation;
 import org.ikuzo.otboo.domain.auth.service.AuthService;
-import org.ikuzo.otboo.global.security.JwtDto;
+import org.ikuzo.otboo.domain.auth.dto.JwtDto;
 import org.ikuzo.otboo.global.security.JwtTokenProvider;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/org/ikuzo/otboo/domain/auth/dto/JwtDto.java
+++ b/src/main/java/org/ikuzo/otboo/domain/auth/dto/JwtDto.java
@@ -1,4 +1,4 @@
-package org.ikuzo.otboo.global.security;
+package org.ikuzo.otboo.domain.auth.dto;
 
 import org.ikuzo.otboo.domain.user.dto.UserDto;
 

--- a/src/main/java/org/ikuzo/otboo/domain/auth/dto/JwtInformation.java
+++ b/src/main/java/org/ikuzo/otboo/domain/auth/dto/JwtInformation.java
@@ -1,0 +1,11 @@
+package org.ikuzo.otboo.domain.auth.dto;
+
+import org.ikuzo.otboo.domain.user.dto.UserDto;
+
+public record JwtInformation(
+    UserDto userDto,
+    String accessToken,
+    String refreshToken
+) {
+
+}

--- a/src/main/java/org/ikuzo/otboo/domain/auth/service/AuthService.java
+++ b/src/main/java/org/ikuzo/otboo/domain/auth/service/AuthService.java
@@ -1,0 +1,7 @@
+package org.ikuzo.otboo.domain.auth.service;
+
+import org.ikuzo.otboo.domain.auth.dto.JwtInformation;
+
+public interface AuthService {
+    JwtInformation refreshToken(String refreshToken);
+}

--- a/src/main/java/org/ikuzo/otboo/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/org/ikuzo/otboo/domain/auth/service/AuthServiceImpl.java
@@ -1,0 +1,51 @@
+package org.ikuzo.otboo.domain.auth.service;
+
+import com.nimbusds.jose.JOSEException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.ikuzo.otboo.domain.auth.dto.JwtInformation;
+import org.ikuzo.otboo.global.exception.ErrorCode;
+import org.ikuzo.otboo.global.exception.OtbooException;
+import org.ikuzo.otboo.global.security.JwtTokenProvider;
+import org.ikuzo.otboo.global.security.OtbooUserDetails;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class AuthServiceImpl implements AuthService {
+
+    private final JwtTokenProvider tokenProvider;
+    private final UserDetailsService userDetailsService;
+
+    @Override
+    public JwtInformation refreshToken(String refreshToken) {
+        // Validate refresh token
+        if (!tokenProvider.validateRefreshToken(refreshToken)) {
+            throw new OtbooException(ErrorCode.INVALID_TOKEN);
+        }
+
+        String email = tokenProvider.getEmailFromToken(refreshToken);
+        UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+
+        if (!(userDetails instanceof OtbooUserDetails otbooUserDetails)) {
+            throw new OtbooException(ErrorCode.INVALID_USER_DETAILS);
+        }
+
+        try {
+            String newAccessToken = tokenProvider.generateAccessToken(otbooUserDetails);
+            String newRefreshToken = tokenProvider.generateRefreshToken(otbooUserDetails);
+            log.info("Access token refreshed for user: {}", email);
+            return new JwtInformation(
+                otbooUserDetails.getUserDto(),
+                newAccessToken,
+                newRefreshToken
+            );
+        } catch (JOSEException e) {
+            log.error("Failed to generate new tokens for user: {}", email, e);
+            throw new OtbooException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/src/main/java/org/ikuzo/otboo/global/config/SecurityConfig.java
+++ b/src/main/java/org/ikuzo/otboo/global/config/SecurityConfig.java
@@ -35,14 +35,14 @@ public class SecurityConfig {
                 .failureHandler(loginFailureHandler)
             )
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers(HttpMethod.POST, "/api/auth/sign-in").permitAll()
-                .requestMatchers(HttpMethod.POST, "/api/auth/refresh").permitAll()
-                .requestMatchers(HttpMethod.POST, "/api/users").permitAll()
-                .requestMatchers(request ->
-                        !request.getRequestURI().startsWith("/api/")
-                ).permitAll()
-                .anyRequest().authenticated()
-//                .anyRequest().permitAll()
+//                .requestMatchers(HttpMethod.POST, "/api/auth/sign-in").permitAll()
+//                .requestMatchers(HttpMethod.POST, "/api/auth/refresh").permitAll()
+//                .requestMatchers(HttpMethod.POST, "/api/users").permitAll()
+//                .requestMatchers(request ->
+//                        !request.getRequestURI().startsWith("/api/")
+//                ).permitAll()
+//                .anyRequest().authenticated()
+                .anyRequest().permitAll()
             )
             .sessionManagement(session -> session
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS)

--- a/src/main/java/org/ikuzo/otboo/global/config/SecurityConfig.java
+++ b/src/main/java/org/ikuzo/otboo/global/config/SecurityConfig.java
@@ -35,13 +35,14 @@ public class SecurityConfig {
                 .failureHandler(loginFailureHandler)
             )
             .authorizeHttpRequests(auth -> auth
-//                .requestMatchers(HttpMethod.POST, "/api/auth/sign-in").permitAll()
-//                .requestMatchers(HttpMethod.POST, "/api/users").permitAll()
-//                .requestMatchers(request ->
-//                        !request.getRequestURI().startsWith("/api/")
-//                ).permitAll()
-//                .anyRequest().authenticated()
-                .anyRequest().permitAll()
+                .requestMatchers(HttpMethod.POST, "/api/auth/sign-in").permitAll()
+                .requestMatchers(HttpMethod.POST, "/api/auth/refresh").permitAll()
+                .requestMatchers(HttpMethod.POST, "/api/users").permitAll()
+                .requestMatchers(request ->
+                        !request.getRequestURI().startsWith("/api/")
+                ).permitAll()
+                .anyRequest().authenticated()
+//                .anyRequest().permitAll()
             )
             .sessionManagement(session -> session
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS)

--- a/src/main/java/org/ikuzo/otboo/global/exception/ErrorCode.java
+++ b/src/main/java/org/ikuzo/otboo/global/exception/ErrorCode.java
@@ -4,6 +4,11 @@ import lombok.Getter;
 
 @Getter
 public enum ErrorCode {
+
+    // Security
+    INVALID_TOKEN("토큰이 유효하지 않습니다."),
+    INVALID_USER_DETAILS("사용자 인증 정보(UserDetails)가 유효하지 않습니다."),
+
     // 사용자
     DUPLICATE_USER("이미 존재하는 사용자입니다."),
     USER_NOT_FOUND("사용자를 찾을 수 없습니다."),

--- a/src/main/java/org/ikuzo/otboo/global/exception/ErrorCode.java
+++ b/src/main/java/org/ikuzo/otboo/global/exception/ErrorCode.java
@@ -21,7 +21,6 @@ public enum ErrorCode {
     CLOTHES_NOT_FOUND("존재하지 않는 의상입니다"),
     CLOTHING_MAPPER_CONVERSION_FAILED("Clothes -> ClothesDto로의 변환에 실패하였습니다"),
 
-
     // 의상 속성
     DUPLICATED_ATTRIBUTE_NAME("이미 존재하는 속성 이름입니다"),
     ATTRIBUTE_NOT_FOUND("존재하지 않는 속성 입니다"),
@@ -37,7 +36,11 @@ public enum ErrorCode {
 
     // 날씨/외부 API
     WEATHER_NO_FORECAST("기상청 예보 데이터가 없습니다."),
-    EXTERNAL_API_ERROR("외부 API 호출 중 오류가 발생했습니다.");
+    EXTERNAL_API_ERROR("외부 API 호출 중 오류가 발생했습니다."),
+
+    // Server 에러
+    INTERNAL_SERVER_ERROR("서버 내부 오류가 발생했습니다.")
+    ;
 
     private final String message;
 

--- a/src/main/java/org/ikuzo/otboo/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/ikuzo/otboo/global/exception/GlobalExceptionHandler.java
@@ -24,7 +24,7 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(OtbooException.class)
-    public ResponseEntity<ErrorResponse> handleDiscodeitException(OtbooException exception) {
+    public ResponseEntity<ErrorResponse> handleOtbooException(OtbooException exception) {
         log.error("커스텀 예외 발생: code={}, message={}", exception.getErrorCode(),
             exception.getMessage(),
             exception);
@@ -67,6 +67,8 @@ public class GlobalExceptionHandler {
             , INVALID_ATTRIBUTE_OPTION -> HttpStatus.BAD_REQUEST;
 
             case ATTRIBUTE_NOT_FOUND, FOLLOW_NOT_FOUND, USER_NOT_FOUND -> HttpStatus.NOT_FOUND;
+
+            case INVALID_TOKEN, INVALID_USER_DETAILS -> HttpStatus.UNAUTHORIZED;
 
             default -> HttpStatus.INTERNAL_SERVER_ERROR;
         };

--- a/src/main/java/org/ikuzo/otboo/global/security/JwtLoginSuccessHandler.java
+++ b/src/main/java/org/ikuzo/otboo/global/security/JwtLoginSuccessHandler.java
@@ -38,7 +38,7 @@ public class JwtLoginSuccessHandler implements AuthenticationSuccessHandler {
                 String refreshToken = tokenProvider.generateRefreshToken(userDetails);
 
                 // Set refresh token in HttpOnly cookie
-                Cookie refreshCookie = tokenProvider.genereateRefreshTokenCookie(refreshToken);
+                Cookie refreshCookie = tokenProvider.generateRefreshTokenCookie(refreshToken);
                 response.addCookie(refreshCookie);
 
                 JwtDto jwtDto = new JwtDto(

--- a/src/main/java/org/ikuzo/otboo/global/security/JwtLoginSuccessHandler.java
+++ b/src/main/java/org/ikuzo/otboo/global/security/JwtLoginSuccessHandler.java
@@ -3,6 +3,7 @@ package org.ikuzo.otboo.global.security;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jose.JOSEException;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -33,6 +34,11 @@ public class JwtLoginSuccessHandler implements AuthenticationSuccessHandler {
         if (authentication.getPrincipal() instanceof OtbooUserDetails userDetails) {
             try {
                 String accessToken = tokenProvider.generateAccessToken(userDetails);
+                String refreshToken = tokenProvider.generateRefreshToken(userDetails);
+
+                // Set refresh token in HttpOnly cookie
+                Cookie refreshCookie = tokenProvider.genereateRefreshTokenCookie(refreshToken);
+                response.addCookie(refreshCookie);
 
                 JwtDto jwtDto = new JwtDto(
                     userDetails.getUserDto(),

--- a/src/main/java/org/ikuzo/otboo/global/security/JwtLoginSuccessHandler.java
+++ b/src/main/java/org/ikuzo/otboo/global/security/JwtLoginSuccessHandler.java
@@ -9,6 +9,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.ikuzo.otboo.domain.auth.dto.JwtDto;
 import org.ikuzo.otboo.global.exception.ErrorResponse;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;

--- a/src/main/java/org/ikuzo/otboo/global/security/JwtTokenProvider.java
+++ b/src/main/java/org/ikuzo/otboo/global/security/JwtTokenProvider.java
@@ -141,7 +141,7 @@ public class JwtTokenProvider {
         }
     }
 
-    public Cookie genereateRefreshTokenCookie(String refreshToken) {
+    public Cookie generateRefreshTokenCookie(String refreshToken) {
         // Set refresh token in HttpOnly cookie
         Cookie refreshCookie = new Cookie(REFRESH_TOKEN_COOKIE_NAME, refreshToken);
         refreshCookie.setHttpOnly(true);

--- a/src/main/java/org/ikuzo/otboo/global/security/JwtTokenProvider.java
+++ b/src/main/java/org/ikuzo/otboo/global/security/JwtTokenProvider.java
@@ -9,6 +9,7 @@ import com.nimbusds.jose.crypto.MACSigner;
 import com.nimbusds.jose.crypto.MACVerifier;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
+import jakarta.servlet.http.Cookie;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.UUID;
@@ -23,25 +24,41 @@ import org.springframework.stereotype.Component;
 @Component
 public class JwtTokenProvider {
 
+    public static final String REFRESH_TOKEN_COOKIE_NAME = "REFRESH_TOKEN";
+
     private final int accessTokenExpirationMs;
+    private final int refreshTokenExpirationMs;
 
     private final JWSSigner accessTokenSigner;
     private final JWSVerifier accessTokenVerifier;
+    private final JWSSigner refreshTokenSigner;
+    private final JWSVerifier refreshTokenVerifier;
 
     public JwtTokenProvider(
         @Value("${otboo.jwt.access-token.secret}") String accessTokenSecret,
-        @Value("${otboo.jwt.access-token.expiration-ms}") int accessTokenExpirationMs)
+        @Value("${otboo.jwt.access-token.expiration-ms}") int accessTokenExpirationMs,
+        @Value("${otboo.jwt.refresh-token.secret}") String refreshTokenSecret,
+        @Value("${otboo.jwt.refresh-token.expiration-ms}") int refreshTokenExpirationMs)
         throws JOSEException {
 
         this.accessTokenExpirationMs = accessTokenExpirationMs;
+        this.refreshTokenExpirationMs = refreshTokenExpirationMs;
 
         byte[] accessSecretBytes = accessTokenSecret.getBytes(StandardCharsets.UTF_8);
         this.accessTokenSigner = new MACSigner(accessSecretBytes);
         this.accessTokenVerifier = new MACVerifier(accessSecretBytes);
+
+        byte[] refreshSecretBytes = refreshTokenSecret.getBytes(StandardCharsets.UTF_8);
+        this.refreshTokenSigner = new MACSigner(refreshSecretBytes);
+        this.refreshTokenVerifier = new MACVerifier(refreshSecretBytes);
     }
 
     public String generateAccessToken(OtbooUserDetails userDetails) throws JOSEException {
         return generateToken(userDetails, accessTokenExpirationMs, accessTokenSigner, "access");
+    }
+
+    public String generateRefreshToken(OtbooUserDetails userDetails) throws JOSEException {
+        return generateToken(userDetails, refreshTokenExpirationMs, refreshTokenSigner, "refresh");
     }
 
     private String generateToken(OtbooUserDetails userDetails, int expirationMs, JWSSigner signer,
@@ -78,6 +95,10 @@ public class JwtTokenProvider {
 
     public boolean validateAccessToken(String token) {
         return validateToken(token, accessTokenVerifier, "access");
+    }
+
+    public boolean validateRefreshToken(String token) {
+        return validateToken(token, refreshTokenVerifier, "refresh");
     }
 
     private boolean validateToken(String token, JWSVerifier verifier, String expectedType) {
@@ -118,5 +139,15 @@ public class JwtTokenProvider {
         } catch (Exception e) {
             throw new IllegalArgumentException("Invalid JWT token", e);
         }
+    }
+
+    public Cookie genereateRefreshTokenCookie(String refreshToken) {
+        // Set refresh token in HttpOnly cookie
+        Cookie refreshCookie = new Cookie(REFRESH_TOKEN_COOKIE_NAME, refreshToken);
+        refreshCookie.setHttpOnly(true);
+        refreshCookie.setSecure(true); // Use HTTPS in production
+        refreshCookie.setPath("/");
+        refreshCookie.setMaxAge(refreshTokenExpirationMs / 1000);
+        return refreshCookie;
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -8,6 +8,10 @@ otboo:
     access-token:
       secret: ${JWT_ACCESS_SECRET}
       expiration-ms: ${JWT_ACCESS_EXPIRATION_MS:3600000} # 60 minutes
+    refresh-token:
+      secret: ${JWT_REFRESH_SECRET}
+      expiration-ms: ${JWT_REFRESH_EXPIRATION_MS:604800000} # 7 days
+
 sse:
   timeout: 300_000
   event-queue-capacity: 100


### PR DESCRIPTION
## 🔧 주요 작업 내용
> 이번 PR에서 작업한 내용을 작성해주세요
- [x] refresh token으로 access token 재발급 기능 구현


---

## ✅ 체크리스트
> PR이 다음 요구 사항을 충족하는지 확인해주세요
- [x] 테스트 코드 작성 또는 수동 테스트 완료
- [x] 커밋 메시지 컨벤션 준수

---

## 📸 스크린샷
> Postman, Swagger UI 등을 통해 직접 확인한 테스트 내용을 첨부해주세요


- 로그인 후 쿠키에 refresh 토큰 저장됨
<img width="2206" height="1201" alt="스크린샷 2025-09-19 140727" src="https://github.com/user-attachments/assets/1529cdfb-a66d-4bda-829c-a8fdea2a914f" />


- 토큰 재발급 성공

<img width="2203" height="1410" alt="스크린샷 2025-09-19 140316" src="https://github.com/user-attachments/assets/000e40c4-fc87-4033-9e9a-de69e1c024b5" />


- 토큰 재발급 실패

<img width="2211" height="1504" alt="스크린샷 2025-09-19 140827" src="https://github.com/user-attachments/assets/e292eae7-9539-4d6e-865b-9d68cc98f063" />


---

## 📎 기타 참고 사항
- 디스코드에서 .env 참고하여 refresh secret key 넣어주세요
- accessToken 60분, refreshToken 7일로 만료기간 설정했습니다
- 개발 편의를 위해 github 상에는 authorizeHttpRequests 모든 요청 허용으로 설정해두었습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - POST /api/auth/refresh 엔드포인트 추가로 쿠키의 리프레시 토큰으로 새 액세스 토큰 및 사용자 정보를 반환합니다.
  - 로그인 성공 시 리프레시 토큰을 HttpOnly 쿠키로 설정합니다.
- Bug Fixes
  - 유효하지 않은 토큰/사용자 인증 정보에 대해 401 응답을 일관되게 반환하도록 예외 매핑을 개선했습니다.
- Chores
  - 리프레시 토큰 발급/검증 및 쿠키 설정 지원과 관련 환경변수(비밀키·만료시간)를 도입했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->