### PR TITLE
[Notification] 알림 삭제 기능

### DIFF
--- a/src/main/java/org/ikuzo/otboo/domain/notification/controller/NotificationController.java
+++ b/src/main/java/org/ikuzo/otboo/domain/notification/controller/NotificationController.java
@@ -6,10 +6,7 @@ import org.ikuzo.otboo.domain.notification.service.NotificationService;
 import org.ikuzo.otboo.global.dto.PageResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.time.Instant;
 import java.util.List;
@@ -31,5 +28,11 @@ public class NotificationController {
         PageResponse<NotificationDto> response = notificationService.getNotifications(cursor, idAfter, limit);
 
         return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @DeleteMapping("{notificationId}")
+    public ResponseEntity<Void> deleteNotification(@PathVariable UUID notificationId) {
+        notificationService.deleteNotification(notificationId);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/src/main/java/org/ikuzo/otboo/domain/notification/exception/NotificationException.java
+++ b/src/main/java/org/ikuzo/otboo/domain/notification/exception/NotificationException.java
@@ -1,0 +1,10 @@
+package org.ikuzo.otboo.domain.notification.exception;
+
+import org.ikuzo.otboo.global.exception.ErrorCode;
+import org.ikuzo.otboo.global.exception.OtbooException;
+
+public class NotificationException extends OtbooException {
+    public NotificationException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/org/ikuzo/otboo/domain/notification/exception/NotificationNotFoundException.java
+++ b/src/main/java/org/ikuzo/otboo/domain/notification/exception/NotificationNotFoundException.java
@@ -1,0 +1,17 @@
+package org.ikuzo.otboo.domain.notification.exception;
+
+import org.ikuzo.otboo.global.exception.ErrorCode;
+
+import java.util.UUID;
+
+public class NotificationNotFoundException extends NotificationException {
+    public NotificationNotFoundException() {
+        super(ErrorCode.NOTIFICATION_NOT_FOUND);
+    }
+
+    public static NotificationNotFoundException notFoundException(UUID notificationId) {
+        NotificationNotFoundException exception = new NotificationNotFoundException();
+        exception.addDetail("id", notificationId);
+        return exception;
+    }
+}

--- a/src/main/java/org/ikuzo/otboo/domain/notification/service/NotificationService.java
+++ b/src/main/java/org/ikuzo/otboo/domain/notification/service/NotificationService.java
@@ -14,4 +14,6 @@ public interface NotificationService {
     void create(Set<UUID> receiverIds, String title, String content, Level level);
 
     PageResponse<NotificationDto> getNotifications(Instant cursor, UUID idAfter, int limit);
+
+    void deleteNotification(UUID notificationId);
 }

--- a/src/main/java/org/ikuzo/otboo/domain/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/org/ikuzo/otboo/domain/notification/service/NotificationServiceImpl.java
@@ -15,7 +15,6 @@ import org.ikuzo.otboo.global.dto.PageResponse;
 import org.ikuzo.otboo.global.event.message.NotificationCreatedEvent;
 import org.ikuzo.otboo.global.security.OtbooUserDetails;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -23,7 +22,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.nio.file.AccessDeniedException;
 import java.time.Instant;
 import java.util.List;
 import java.util.Set;

--- a/src/main/java/org/ikuzo/otboo/global/exception/ErrorCode.java
+++ b/src/main/java/org/ikuzo/otboo/global/exception/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
     CLOTHES_NOT_FOUND("존재하지 않는 의상입니다"),
     CLOTHING_MAPPER_CONVERSION_FAILED("Clothes -> ClothesDto로의 변환에 실패하였습니다"),
 
+
     // 의상 속성
     DUPLICATED_ATTRIBUTE_NAME("이미 존재하는 속성 이름입니다"),
     ATTRIBUTE_NOT_FOUND("존재하지 않는 속성 입니다"),
@@ -43,9 +44,11 @@ public enum ErrorCode {
     WEATHER_NO_FORECAST("기상청 예보 데이터가 없습니다."),
     EXTERNAL_API_ERROR("외부 API 호출 중 오류가 발생했습니다."),
 
+    // 알림
+    NOTIFICATION_NOT_FOUND("존재하지 않는 알림 입니다."),
+
     // Server 에러
-    INTERNAL_SERVER_ERROR("서버 내부 오류가 발생했습니다.")
-    ;
+    INTERNAL_SERVER_ERROR("서버 내부 오류가 발생했습니다.");
 
     private final String message;
 

--- a/src/main/java/org/ikuzo/otboo/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/ikuzo/otboo/global/exception/GlobalExceptionHandler.java
@@ -59,14 +59,14 @@ public class GlobalExceptionHandler {
 
     private HttpStatus determineHttpStatus(OtbooException exception) {
         return switch (exception.getErrorCode()) {
-
+            
             case DUPLICATE_USER -> HttpStatus.CONFLICT;
 
             case FOLLOW_SELF_NOT_ALLOWED, FOLLOW_ALREADY_EXISTS
             , DUPLICATED_ATTRIBUTE_NAME, REQUIRED_FIELD_MISSING
             , INVALID_ATTRIBUTE_OPTION -> HttpStatus.BAD_REQUEST;
 
-            case ATTRIBUTE_NOT_FOUND, FOLLOW_NOT_FOUND, USER_NOT_FOUND, FEED_CLOTHES_NOT_FOUND, WEATHER_NOT_FOUND ->
+            case ATTRIBUTE_NOT_FOUND, FOLLOW_NOT_FOUND, USER_NOT_FOUND, FEED_CLOTHES_NOT_FOUND, WEATHER_NOT_FOUND, NOTIFICATION_NOT_FOUND ->
                 HttpStatus.NOT_FOUND;
 
             case INVALID_TOKEN, INVALID_USER_DETAILS -> HttpStatus.UNAUTHORIZED;


### PR DESCRIPTION
## 🔧 주요 작업 내용
> 이번 PR에서 작업한 내용을 작성해주세요
- [x] 알림 삭제 API 추가 /api/notifications/{notificationId}
- [x] NotificationNotFoundException 커스텀 예외 추가 

---

## ✅ 체크리스트
> PR이 다음 요구 사항을 충족하는지 확인해주세요
- [x] 테스트 코드 작성 또는 수동 테스트 완료
- [x] 커밋 메시지 컨벤션 준수

---

## 📸 스크린샷
> Postman, Swagger UI 등을 통해 직접 확인한 테스트 내용을 첨부해주세요
- 정상 응답
  <img width="1810" height="728" alt="image" src="https://github.com/user-attachments/assets/1cdb0484-c697-4c9f-8ae4-27b8ef0fabdf" />

---

## 📎 기타 참고 사항
- 추가 논의가 필요한 사항
- 관련 이슈, API 문서 링크 등

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 알림 삭제 기능 추가: /api/notifications/{notificationId} DELETE 엔드포인트 제공, 성공 시 204 반환.
  * 권한 검증 강화: 알림 수신자 본인만 삭제 가능하며 권한 없을 경우 삭제 거부.

* **Bug Fixes / 개선**
  * 존재하지 않는 알림 요청 시 명확한 오류 코드(NOTIFICATION_NOT_FOUND)로 404 응답 매핑 및 안내 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->