### PR TITLE
[DM] Websocket 인증/인가 처리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+	implementation 'org.springframework.security:spring-security-messaging'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'com.nimbusds:nimbus-jose-jwt:10.3'
 

--- a/src/main/java/org/ikuzo/otboo/global/config/SecurityConfig.java
+++ b/src/main/java/org/ikuzo/otboo/global/config/SecurityConfig.java
@@ -1,11 +1,14 @@
 package org.ikuzo.otboo.global.config;
 
+import org.ikuzo.otboo.domain.user.entity.Role;
 import org.ikuzo.otboo.global.security.JwtAuthenticationFilter;
 import org.ikuzo.otboo.global.security.JwtLoginSuccessHandler;
 import org.ikuzo.otboo.global.security.LoginFailureHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -56,6 +59,14 @@ public class SecurityConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public RoleHierarchy roleHierarchy() {
+        return RoleHierarchyImpl.withDefaultRolePrefix()
+            .role(Role.ADMIN.name())
+            .implies(Role.USER.name())
+            .build();
     }
 }
 

--- a/src/main/java/org/ikuzo/otboo/global/config/WebsocketConfig.java
+++ b/src/main/java/org/ikuzo/otboo/global/config/WebsocketConfig.java
@@ -1,14 +1,24 @@
 package org.ikuzo.otboo.global.config;
 
+import lombok.RequiredArgsConstructor;
+import org.ikuzo.otboo.domain.user.entity.Role;
+import org.ikuzo.otboo.global.security.JwtAuthenticationChannelInterceptor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.security.messaging.access.intercept.AuthorizationChannelInterceptor;
+import org.springframework.security.messaging.access.intercept.MessageMatcherDelegatingAuthorizationManager;
+import org.springframework.security.messaging.context.SecurityContextChannelInterceptor;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
 @Configuration
 @EnableWebSocketMessageBroker
+@RequiredArgsConstructor
 public class WebsocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final JwtAuthenticationChannelInterceptor jwtAuthenticationChannelInterceptor;
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry config) {
@@ -21,5 +31,22 @@ public class WebsocketConfig implements WebSocketMessageBrokerConfigurer {
         registry.addEndpoint("/ws")
             .setAllowedOriginPatterns("*")
             .withSockJS();
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(
+            jwtAuthenticationChannelInterceptor,
+            new SecurityContextChannelInterceptor(),
+            authorizationChannelInterceptor()
+        );
+    }
+
+    private AuthorizationChannelInterceptor authorizationChannelInterceptor() {
+        return new AuthorizationChannelInterceptor(
+            MessageMatcherDelegatingAuthorizationManager.builder()
+                .anyMessage().hasRole(Role.USER.name())
+                .build()
+        );
     }
 }

--- a/src/main/java/org/ikuzo/otboo/global/security/JwtAuthenticationChannelInterceptor.java
+++ b/src/main/java/org/ikuzo/otboo/global/security/JwtAuthenticationChannelInterceptor.java
@@ -1,0 +1,66 @@
+package org.ikuzo.otboo.global.security;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.ikuzo.otboo.global.exception.ErrorCode;
+import org.ikuzo.otboo.global.exception.OtbooException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationChannelInterceptor implements ChannelInterceptor {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RoleHierarchy roleHierarchy;
+    private final OtbooUserDetailsService userDetailsService;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+        if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+            String token = resolveToken(accessor).orElseThrow(() -> new OtbooException(ErrorCode.INVALID_TOKEN));
+
+            if (jwtTokenProvider.validateAccessToken(token)) {
+                String email = jwtTokenProvider.getEmailFromToken(token);
+                UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+
+                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                    userDetails,
+                    null,
+                    roleHierarchy.getReachableGrantedAuthorities(userDetails.getAuthorities())
+                );
+
+                accessor.setUser(authentication);
+            } else {
+                throw new OtbooException(ErrorCode.INVALID_TOKEN);
+            }
+        }
+        return message;
+    }
+
+    private Optional<String> resolveToken(StompHeaderAccessor accessor) {
+        String prefix = "Bearer ";
+        return Optional.ofNullable(accessor.getFirstNativeHeader(HttpHeaders.AUTHORIZATION))
+            .map(value -> {
+                if (value.startsWith(prefix)) {
+                    return value.substring(prefix.length());
+                } else {
+                    return null;
+                }
+            });
+    }
+}

--- a/src/main/resources/static/websocket-test.html
+++ b/src/main/resources/static/websocket-test.html
@@ -113,6 +113,10 @@
                 <label for="serverUrl">서버 URL:</label>
                 <input type="text" id="serverUrl" value="http://localhost:8080/ws" placeholder="ws://localhost:8080/ws">
             </div>
+            <div class="form-group">
+                <label for="jwtToken">JWT 토큰:</label>
+                <textarea id="jwtToken" rows="3" placeholder="Bearer 토큰을 입력하세요 (Bearer 제외하고 토큰만 입력)"></textarea>
+            </div>
             <button id="connectBtn" onclick="connect()">연결</button>
             <button id="disconnectBtn" onclick="disconnect()" disabled>연결 해제</button>
         </div>
@@ -135,6 +139,20 @@
         </div>
 
         <div class="message-form">
+            <h3>테스트 도움말</h3>
+            <div style="background-color: #e7f3ff; padding: 15px; border-radius: 4px; margin: 10px 0;">
+                <h4>사용 방법:</h4>
+                <ol>
+                    <li><strong>JWT 토큰 획득:</strong> 먼저 로그인 API를 호출하여 유효한 JWT 토큰을 받아주세요.</li>
+                    <li><strong>토큰 입력:</strong> 위의 JWT 토큰 필드에 Bearer 제외한 토큰만 입력하세요.</li>
+                    <li><strong>연결:</strong> 연결 버튼을 클릭하여 WebSocket 연결을 시도하세요.</li>
+                    <li><strong>메시지 전송:</strong> 연결 성공 후 메시지를 전송할 수 있습니다.</li>
+                </ol>
+                <p><strong>참고:</strong> 토큰이 유효하지 않거나 권한이 없으면 연결이 실패합니다.</p>
+            </div>
+        </div>
+
+        <div class="message-form">
             <h3>메시지 로그</h3>
             <button onclick="clearMessages()">로그 지우기</button>
             <div id="messages" class="messages"></div>
@@ -147,9 +165,15 @@
 
         function connect() {
             const serverUrl = document.getElementById('serverUrl').value;
+            const jwtToken = document.getElementById('jwtToken').value.trim();
             
             if (!serverUrl) {
                 alert('서버 URL을 입력해주세요.');
+                return;
+            }
+
+            if (!jwtToken) {
+                alert('JWT 토큰을 입력해주세요.');
                 return;
             }
 
@@ -160,8 +184,13 @@
             // 디버그 로그 비활성화 (선택사항)
             stompClient.debug = null;
 
+            // 연결 헤더에 JWT 토큰 포함
+            const headers = {
+                Authorization: 'Bearer ' + jwtToken
+            };
+
             // 연결 시도
-            stompClient.connect({}, function (frame) {
+            stompClient.connect(headers, function (frame) {
                 console.log('Connected: ' + frame);
                 isConnected = true;
                 updateConnectionStatus(true);
@@ -187,7 +216,20 @@
                 addMessage('system', 'WebSocket 연결이 성공했습니다.');
             }, function (error) {
                 console.log('Connection error: ' + error);
-                addMessage('system', '연결 오류: ' + error);
+                
+                // 에러 타입에 따른 메시지 구분
+                let errorMessage = '연결 오류: ';
+                if (error.includes('401') || error.includes('Unauthorized')) {
+                    errorMessage += '인증 실패 - JWT 토큰을 확인해주세요.';
+                } else if (error.includes('403') || error.includes('Forbidden')) {
+                    errorMessage += '권한 없음 - 해당 리소스에 접근할 권한이 없습니다.';
+                } else if (error.includes('Connection refused')) {
+                    errorMessage += '서버에 연결할 수 없습니다. 서버가 실행 중인지 확인해주세요.';
+                } else {
+                    errorMessage += error;
+                }
+                
+                addMessage('system', errorMessage);
                 updateConnectionStatus(false);
             });
         }


### PR DESCRIPTION
## 🔧 주요 작업 내용
> 이번 PR에서 작업한 내용을 작성해주세요
- [x] JwtAuthenticationChannelInterceptor 구현
- [x] Role.User 이상 인증/인가 처리 진행 

---

## ✅ 체크리스트
> PR이 다음 요구 사항을 충족하는지 확인해주세요
- [x] 테스트 코드 작성 또는 수동 테스트 완료
- [x] 커밋 메시지 컨벤션 준수

---

## 📸 스크린샷
> Postman, Swagger UI 등을 통해 직접 확인한 테스트 내용을 첨부해주세요
- 정상 연결 확인
  <img width="1592" height="996" alt="image" src="https://github.com/user-attachments/assets/c1935daf-6a5e-4e84-b5ab-af62d9dae6da" />
  <img width="3194" height="58" alt="image" src="https://github.com/user-attachments/assets/aff4b2a1-a143-4945-a43b-b103597eb0f3" />

---

## 📎 기타 참고 사항
- 추가 논의가 필요한 사항
- 관련 이슈, API 문서 링크 등

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 웹소켓(STOMP)에 JWT 인증을 도입해 연결 시 토큰 검증과 사용자 인증을 수행합니다.
  * 역할 계층(ADMIN > USER) 지원으로 메시지 채널에서 역할 기반 접근 제어가 일관되게 적용됩니다.
  * 인증된 사용자만 구독/전송 가능하며, 인증 실패 시 연결이 거부됩니다.
* 작업(Chores)
  * 메시징 보안 강화를 위한 관련 의존성을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->