### PR TITLE
[Auth] Oauth2 로그인 - 구글

### DIFF
--- a/src/main/java/org/ikuzo/otboo/global/oauth2/dto/GoogleUserInfo.java
+++ b/src/main/java/org/ikuzo/otboo/global/oauth2/dto/GoogleUserInfo.java
@@ -1,0 +1,37 @@
+package org.ikuzo.otboo.global.oauth2.dto;
+
+import java.util.Map;
+
+public class GoogleUserInfo implements Oauth2UserInfo {
+
+    private final Map<String, Object> attributes;
+
+    public GoogleUserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) attributes.get("email");
+    }
+
+    @Override
+    public String getProviderId() {
+        return (String) attributes.get("sub");
+    }
+
+    @Override
+    public String getProvider() {
+        return "google";
+    }
+
+    @Override
+    public String getNickname() {
+        return (String) attributes.get("family_name") + (String) attributes.get("given_name");
+    }
+
+    @Override
+    public String getProfileImageUrl() {
+        return (String) attributes.get("picture");
+    }
+}

--- a/src/main/java/org/ikuzo/otboo/global/oauth2/service/Oauth2UserServiceImpl.java
+++ b/src/main/java/org/ikuzo/otboo/global/oauth2/service/Oauth2UserServiceImpl.java
@@ -6,6 +6,7 @@ import org.ikuzo.otboo.domain.user.dto.UserDto;
 import org.ikuzo.otboo.domain.user.entity.User;
 import org.ikuzo.otboo.domain.user.mapper.UserMapper;
 import org.ikuzo.otboo.domain.user.repository.UserRepository;
+import org.ikuzo.otboo.global.oauth2.dto.GoogleUserInfo;
 import org.ikuzo.otboo.global.oauth2.dto.KakaoUserInfo;
 import org.ikuzo.otboo.global.oauth2.dto.Oauth2UserInfo;
 import org.ikuzo.otboo.global.security.OtbooUserDetails;
@@ -35,6 +36,8 @@ public class Oauth2UserServiceImpl extends DefaultOAuth2UserService {
 
         if (userRequest.getClientRegistration().getRegistrationId().equals("kakao")) {
             oauth2UserInfo = new KakaoUserInfo(oAuth2User.getAttributes());
+        } else if (userRequest.getClientRegistration().getRegistrationId().equals("google")) {
+            oauth2UserInfo = new GoogleUserInfo(oAuth2User.getAttributes());
         }
 
         String email = oauth2UserInfo.getEmail();
@@ -47,7 +50,7 @@ public class Oauth2UserServiceImpl extends DefaultOAuth2UserService {
 
         UserDto userDto = null;
         if (findUser.isEmpty()) {
-            log.info("[Oauth2UserService] Kakao 최초 로그인");
+            log.info("[Oauth2UserService] Oauth2 최초 로그인");
 
             User user = new User(
                 email,

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -16,6 +16,15 @@ spring:
             redirect-uri: "{baseUrl}/oauth2/callback/kakao"
             authorization-grant-type: authorization_code
             client-authentication-method: client_secret_post
+          google:
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+            scope:
+              - email
+              - profile
+            redirect-uri: "{baseUrl}/oauth2/callback/google"
+            authorization-grant-type: authorization_code
+            client-authentication-method: client_secret_post
         provider:
           kakao:
             authorization-uri: https://kauth.kakao.com/oauth/authorize

--- a/src/main/resources/static/kakao-login-test.html
+++ b/src/main/resources/static/kakao-login-test.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>카카오 로그인 테스트</title>
+    <title>OAuth2 로그인 테스트 (카카오/구글)</title>
     <style>
         body {
             font-family: Arial, sans-serif;
@@ -53,20 +53,21 @@
 </head>
 <body>
     <div class="container">
-        <h1>카카오 로그인 테스트</h1>
+        <h1>OAuth2 로그인 테스트 (카카오/구글)</h1>
         
         <div class="info">
             <h3>사용 방법:</h3>
             <ol>
-                <li>아래 버튼을 클릭하여 카카오 로그인을 시도합니다.</li>
+                <li>아래 버튼을 클릭하여 카카오 또는 구글 로그인을 시도합니다.</li>
                 <li>올바른 URL로 리다이렉션되는지 확인합니다.</li>
-                <li>카카오 로그인 후 JWT 토큰을 받을 수 있는지 확인합니다.</li>
+                <li>로그인 후 JWT 토큰을 받을 수 있는지 확인합니다.</li>
             </ol>
         </div>
 
         <div>
             <h3>로그인 방법 선택:</h3>
             
+            <h4>카카오 로그인:</h4>
             <a href="http://localhost:8080/oauth2/authorization/kakao" class="kakao-btn">
                 🚀 절대 URL로 카카오 로그인
             </a>
@@ -82,6 +83,13 @@
             <button onclick="loginWithDynamicUrl()" class="kakao-btn">
                 🔧 동적 URL로 카카오 로그인
             </button>
+            
+            <br><br>
+            
+            <h4>구글 로그인:</h4>
+            <a href="http://localhost:8080/oauth2/authorization/google" class="kakao-btn" style="background-color: #4285f4;">
+                🔍 구글 로그인
+            </a>
         </div>
 
         <div id="status" style="margin-top: 20px;"></div>


### PR DESCRIPTION
## 🔧 주요 작업 내용
> 이번 PR에서 작업한 내용을 작성해주세요
- [x] 구글 소셜 로그인 기능 구현

---

## ✅ 체크리스트
> PR이 다음 요구 사항을 충족하는지 확인해주세요
- [x] 테스트 코드 작성 또는 수동 테스트 완료
- [x] 커밋 메시지 컨벤션 준수

---

## 📸 스크린샷
> Postman, Swagger UI 등을 통해 직접 확인한 테스트 내용을 첨부해주세요
- 정상 동작
   ![화면 기록 2025-09-22 17 43 16 mov](https://github.com/user-attachments/assets/8fe795f5-03ba-4b3b-b0ef-d7e4022d445a)

---

## 📎 기타 참고 사항
- 추가 논의가 필요한 사항
- 관련 이슈, API 문서 링크 등
- 현재 프론트 소스 기준 카카오 로그인 버튼 클릭 시 http://oauth2/authorization/google baseUrl인 localhost이 빠진 상태로 요청이 날아가는 문제 발생
  - 강사님께 전달하여 확인중

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 구글 OAuth2 로그인 지원 추가(이메일·프로필 범위).  
  - OAuth2 테스트 페이지에서 구글/카카오 선택 로그인 버튼 제공 및 안내 문구 일반화.

- 작업
  - 구글 OAuth2 클라이언트 환경설정 추가(클라이언트 ID/시크릿, 리다이렉트 URI, 스코프 등).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->