### PR TITLE
[Follow] 팔로우 도메인 리팩토링

### DIFF
--- a/src/main/java/org/ikuzo/otboo/domain/follow/controller/FollowController.java
+++ b/src/main/java/org/ikuzo/otboo/domain/follow/controller/FollowController.java
@@ -49,14 +49,14 @@ public class FollowController {
 
     @GetMapping("/followings")
     public ResponseEntity<PageResponse<FollowDto>> followings(
-        @RequestParam UUID followeeId,
+        @RequestParam UUID followerId,
         @RequestParam(required = false) String cursor,
         @RequestParam(required = false) UUID idAfter,
         @RequestParam int limit,
         @RequestParam(required = false) String nameLike
     ) {
-        log.info("[FollowController] 팔로잉 목록 조회 컨트롤러 진입 followeeId: {}, cursor: {}, idAfter: {}, limit: {}, nameLike: {}", followeeId, cursor, idAfter,  limit, nameLike);
-        PageResponse<FollowDto> response = followService.getFollowings(followeeId, cursor, idAfter, limit, nameLike);
+        log.info("[FollowController] 팔로잉 목록 조회 컨트롤러 진입 followeeId: {}, cursor: {}, idAfter: {}, limit: {}, nameLike: {}", followerId, cursor, idAfter,  limit, nameLike);
+        PageResponse<FollowDto> response = followService.getFollowings(followerId, cursor, idAfter, limit, nameLike);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 


### PR DESCRIPTION
## 🔧 주요 작업 내용
> 이번 PR에서 작업한 내용을 작성해주세요
- [x] FollowController.followings() 파라미터 수정
  - [x] followeeId -> followerId 
- [x] FollowService Cache 전략 수정
---

## ✅ 체크리스트
> PR이 다음 요구 사항을 충족하는지 확인해주세요
- [x] 테스트 코드 작성 또는 수동 테스트 완료
- [x] 커밋 메시지 컨벤션 준수

---

## 📸 스크린샷
> Postman, Swagger UI 등을 통해 직접 확인한 테스트 내용을 첨부해주세요

---

## 📎 기타 참고 사항
- 추가 논의가 필요한 사항
- 관련 이슈, API 문서 링크 등

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능: 해당 없음
- 버그 수정
  - 팔로우/언팔로우 후 목록과 요약이 즉시 최신 상태로 반영되도록 캐시 무효화 개선
  - 사용자 간 캐시 충돌로 잘못된 팔로우 정보가 노출되던 문제 해결
- 리팩터링
  - 팔로잉 목록 조회 API의 요청 파라미터를 followerId로 정리(기존 followeeId에서 변경). 클라이언트 요청 업데이트 필요
- 작업(Chores)
  - 캐시 키 전략을 사용자별로 더 세분화해 정확도 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->