### PR TITLE
[Auth] CSRF 토큰 조회 구현

### DIFF
--- a/src/main/java/org/ikuzo/otboo/domain/auth/controller/AuthController.java
+++ b/src/main/java/org/ikuzo/otboo/domain/auth/controller/AuthController.java
@@ -15,7 +15,9 @@ import org.ikuzo.otboo.domain.user.dto.UserRoleUpdateRequest;
 import org.ikuzo.otboo.global.security.JwtTokenProvider;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.web.csrf.CsrfToken;
 import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -57,5 +59,14 @@ public class AuthController {
         log.info("비밀번호 초기화 요청: email={}", request.email());
         authService.resetPassword(request);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("csrf-token")
+    public ResponseEntity<Void> getCsrfToken(CsrfToken csrfToken) {
+        log.debug("CSRF 토큰 요청");
+        log.trace("CSRF 토큰: {}", csrfToken.getToken());
+        return ResponseEntity
+            .status(HttpStatus.NO_CONTENT)
+            .build();
     }
 }

--- a/src/main/java/org/ikuzo/otboo/global/config/SecurityConfig.java
+++ b/src/main/java/org/ikuzo/otboo/global/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import org.ikuzo.otboo.global.security.JwtAuthenticationFilter;
 import org.ikuzo.otboo.global.security.JwtLoginSuccessHandler;
 import org.ikuzo.otboo.global.security.JwtLogoutHandler;
 import org.ikuzo.otboo.global.security.LoginFailureHandler;
+import org.ikuzo.otboo.global.security.SpaCsrfTokenRequestHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -26,6 +27,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.Http403ForbiddenEntryPoint;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.authentication.logout.HttpStatusReturningLogoutSuccessHandler;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 
 @Configuration
 @EnableWebSecurity
@@ -43,7 +45,10 @@ public class SecurityConfig {
         Oauth2LoginSuccessHandler oauth2LoginSuccessHandler
     ) throws Exception {
         http
-            .csrf(csrf -> csrf.disable())
+            .csrf(csrf -> csrf
+                .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+                .csrfTokenRequestHandler(new SpaCsrfTokenRequestHandler())
+            )
             .cors(cors -> cors.disable())
             .formLogin(login -> login
                 .loginProcessingUrl("/api/auth/sign-in")
@@ -64,15 +69,16 @@ public class SecurityConfig {
                 .successHandler(oauth2LoginSuccessHandler)
             )
             .authorizeHttpRequests(auth -> auth
-//                .requestMatchers(HttpMethod.POST, "/api/auth/sign-in").permitAll()
-//                .requestMatchers(HttpMethod.POST, "/api/auth/refresh").permitAll()
-//                .requestMatchers(HttpMethod.POST, "/api/auth/reset-password").permitAll()
-//                .requestMatchers(HttpMethod.POST, "/api/users").permitAll()
-//                .requestMatchers(request ->
-//                        !request.getRequestURI().startsWith("/api/")
-//                ).permitAll()
-//                .anyRequest().authenticated()
-                    .anyRequest().permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/auth/csrf-token").permitAll()
+                .requestMatchers(HttpMethod.POST, "/api/auth/sign-in").permitAll()
+                .requestMatchers(HttpMethod.POST, "/api/auth/refresh").permitAll()
+                .requestMatchers(HttpMethod.POST, "/api/auth/sign-out").permitAll()
+                .requestMatchers(HttpMethod.POST, "/api/auth/reset-password").permitAll()
+                .requestMatchers(HttpMethod.POST, "/api/users").permitAll()
+                .requestMatchers(request ->
+                        !request.getRequestURI().startsWith("/api/")
+                ).permitAll()
+                .anyRequest().authenticated()
             )
             .exceptionHandling(ex -> ex
                 .authenticationEntryPoint(new Http403ForbiddenEntryPoint())

--- a/src/main/java/org/ikuzo/otboo/global/security/SpaCsrfTokenRequestHandler.java
+++ b/src/main/java/org/ikuzo/otboo/global/security/SpaCsrfTokenRequestHandler.java
@@ -1,0 +1,48 @@
+package org.ikuzo.otboo.global.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.function.Supplier;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
+import org.springframework.security.web.csrf.CsrfTokenRequestHandler;
+import org.springframework.security.web.csrf.XorCsrfTokenRequestAttributeHandler;
+import org.springframework.util.StringUtils;
+
+public class SpaCsrfTokenRequestHandler implements CsrfTokenRequestHandler {
+
+  private final CsrfTokenRequestHandler plain = new CsrfTokenRequestAttributeHandler();
+  private final CsrfTokenRequestHandler xor = new XorCsrfTokenRequestAttributeHandler();
+
+  @Override
+  public void handle(HttpServletRequest request, HttpServletResponse response,
+      Supplier<CsrfToken> csrfToken) {
+    /*
+     * Always use XorCsrfTokenRequestAttributeHandler to provide BREACH protection of
+     * the CsrfToken when it is rendered in the response body.
+     */
+    this.xor.handle(request, response, csrfToken);
+    /*
+     * Render the token value to a cookie by causing the deferred token to be loaded.
+     */
+    csrfToken.get();
+  }
+
+  @Override
+  public String resolveCsrfTokenValue(HttpServletRequest request, CsrfToken csrfToken) {
+    String headerValue = request.getHeader(csrfToken.getHeaderName());
+    /*
+     * If the request contains a request header, use CsrfTokenRequestAttributeHandler
+     * to resolve the CsrfToken. This applies when a single-page application includes
+     * the header value automatically, which was obtained via a cookie containing the
+     * raw CsrfToken.
+     *
+     * In all other cases (e.g. if the request contains a request parameter), use
+     * XorCsrfTokenRequestAttributeHandler to resolve the CsrfToken. This applies
+     * when a server-side rendered form includes the _csrf request parameter as a
+     * hidden input.
+     */
+    return (StringUtils.hasText(headerValue) ? this.plain : this.xor).resolveCsrfTokenValue(request,
+        csrfToken);
+  }
+}


### PR DESCRIPTION
## 🔧 주요 작업 내용
> 이번 PR에서 작업한 내용을 작성해주세요
- [x] CSRF 토큰 조회 기능 구현
- [x] authorizeHttpRequests 설정

---

## ✅ 체크리스트
> PR이 다음 요구 사항을 충족하는지 확인해주세요
- [x] 테스트 코드 작성 또는 수동 테스트 완료
- [x] 커밋 메시지 컨벤션 준수

---

## 📸 스크린샷
> Postman, Swagger UI 등을 통해 직접 확인한 테스트 내용을 첨부해주세요
<img width="2879" height="898" alt="스크린샷 2025-09-30 115625" src="https://github.com/user-attachments/assets/38b84fa4-be93-4987-acc4-35bcff1ab2e1" />

---

## 📎 기타 참고 사항
- anyRequest().permitAll() 삭제했습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 새로운 기능
  - CSRF 토큰 조회 엔드포인트 추가(204 응답)로 클라이언트가 안전하게 토큰을 획득 가능.
  - SPA 친화적 쿠키 기반 CSRF 보호 적용: 초기 로드 시 토큰 제공, 헤더/폼 제출 모두 지원.
  - 인증 관련 엔드포인트(로그인, 갱신, 로그아웃, 비밀번호 재설정, 사용자 등록 등) 접근 규칙을 명확화하여 예측 가능한 동작 보장.
  - 비-API 요청은 기본 허용, 그 외 API는 인증 필요로 보안 강화.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->